### PR TITLE
Refactor currency service networking

### DIFF
--- a/Pesoblu/Utils/APIConfig.swift
+++ b/Pesoblu/Utils/APIConfig.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct APIConfig {
+    static let apiKey = "99f81f10b5b6b92679b9051bdce40b7647f150e0"
+    static let currencyBaseURL = "https://api.getgeoapi.com/v2/currency/convert"
+    static let dolarAPIBaseURL = "https://dolarapi.com/v1/dolares"
+    static var dolarBlueURL: String { "\(dolarAPIBaseURL)/blue" }
+    static var dolarOficialURL: String { "\(dolarAPIBaseURL)/oficial" }
+    static var dolarMepURL: String { "\(dolarAPIBaseURL)/bolsa" }
+}


### PR DESCRIPTION
## Summary
- Centralize API endpoints and key in new `APIConfig`
- Update `CurrencyService` to use `URLSession` off the main actor and return results on the main thread

## Testing
- `swift test` (fails: Could not find Package.swift)
- `swift build` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_6892a530a9b083338a53a67e1b2aeb1f