### PR TITLE
Unify PlacesList naming

### DIFF
--- a/Pesoblu.xcodeproj/xcuserdata/danielcarcacha.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Pesoblu.xcodeproj/xcuserdata/danielcarcacha.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -43,7 +43,7 @@
             shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "PesoBlueMVVM/PlacesListViewModel/FilterCollectionView/FilterCollectionView.swift"
+            filePath = "Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "25"
@@ -185,12 +185,12 @@
             shouldBeEnabled = "Yes"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "Pesoblu/PlacesListViewModel/View/PlacesListViewController.swift"
+             filePath = "Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
             startingLineNumber = "166"
             endingLineNumber = "166"
-            landmarkName = "placeListCViewDidFailToLoadImage(_:error:)"
+            landmarkName = "placesListCollectionViewDidFailToLoadImage(_:error:)"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/Pesoblu/Coordinators/HomeCoordinator.swift
+++ b/Pesoblu/Coordinators/HomeCoordinator.swift
@@ -8,7 +8,7 @@ import UIKit
 
 class HomeCoordinator: Coordinator {
     var navigationController: UINavigationController
-    private var placeListCoordinator: PlaceListCoordinator?
+    private var placesListCoordinator: PlacesListCoordinator?
 
     init() {
         self.navigationController = UINavigationController()
@@ -25,7 +25,7 @@ class HomeCoordinator: Coordinator {
         let vc = HomeViewController(homeViewModel: viewModel)
         
         vc.onSelect = { [weak self] selectedPlaces, selectedCity, placeType in
-            self?.showPlaceListWithCity(selectedPlaces: selectedPlaces, selectedCity: selectedCity, placeType: placeType)
+            self?.showPlacesListWithCity(selectedPlaces: selectedPlaces, selectedCity: selectedCity, placeType: placeType)
         }
         
         vc.title = "Home"
@@ -33,12 +33,12 @@ class HomeCoordinator: Coordinator {
         navigationController.setViewControllers([vc], animated: false)
     }
     
-    func showPlaceListWithCity(selectedPlaces: [PlaceItem], selectedCity: String, placeType: String){
+    func showPlacesListWithCity(selectedPlaces: [PlaceItem], selectedCity: String, placeType: String){
         
-        let viewModel = PlaceListViewModel(distanceService: DistanceService(locationProvider: LocationManager()), filterDataService: FilterDataService())
-        let coordinator = PlaceListCoordinator(navigationController: navigationController, placeListViewModel: viewModel, selectedPlaces: selectedPlaces, selectedCity: selectedCity, placeType: placeType)
-        
-        placeListCoordinator = coordinator
+        let viewModel = PlacesListViewModel(distanceService: DistanceService(locationProvider: LocationManager()), filterDataService: FilterDataService())
+        let coordinator = PlacesListCoordinator(navigationController: navigationController, placesListViewModel: viewModel, selectedPlaces: selectedPlaces, selectedCity: selectedCity, placeType: placeType)
+
+        placesListCoordinator = coordinator
         coordinator.start()
         
     }

--- a/Pesoblu/Coordinators/PlacesListCoordinator.swift
+++ b/Pesoblu/Coordinators/PlacesListCoordinator.swift
@@ -1,33 +1,33 @@
 //
-//  PlaceListCoordinator.swift
+//  PlacesListCoordinator.swift
 //  Pesoblu
 //
 //  Created by Daniel Carcacha on 23/07/2025.
 //
 import UIKit
 
-class PlaceListCoordinator: Coordinator{
+class PlacesListCoordinator: Coordinator {
     var navigationController: UINavigationController
-    private let placeListViewModel: PlaceListViewModelProtocol
+    private let placesListViewModel: PlacesListViewModelProtocol
     private let selectedPlaces: [PlaceItem]
     private let selectedCity: String
     private let placeType: String
     private var placeCoordinator: PlaceCoordinator?
-    
+
     init(navigationController: UINavigationController,
-         placeListViewModel: PlaceListViewModelProtocol,
+         placesListViewModel: PlacesListViewModelProtocol,
          selectedPlaces: [PlaceItem],
          selectedCity: String,
          placeType: String) {
         self.navigationController = navigationController
-        self.placeListViewModel = placeListViewModel
+        self.placesListViewModel = placesListViewModel
         self.selectedPlaces = selectedPlaces
         self.selectedCity = selectedCity
         self.placeType = placeType
     }
     
     func start() {
-        let listVC = PlacesListViewController(placeListViewModel: placeListViewModel,
+        let listVC = PlacesListViewController(placesListViewModel: placesListViewModel,
                                               selectedPlaces: selectedPlaces,
                                               selectedCity: selectedCity,
                                               placeType: placeType)

--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -12,22 +12,22 @@ import CoreData
 class PlacesListViewController: UIViewController {
     
     var onSelect: ((PlaceItem) -> Void)?
-    var filterCView : FilterCollectionView
-    var placeListCView : PlaceListCollectionView
-    var placeListViewModel : PlaceListViewModelProtocol
+    var filterCView: FilterCollectionView
+    var placesListCView: PlacesListCollectionView
+    var placesListViewModel: PlacesListViewModelProtocol
     var selectedPlaces: [PlaceItem]
     var selectedCity: String
     var placeType: String
     
-    init(placeListViewModel: PlaceListViewModelProtocol,
-         filterCView : FilterCollectionView? = nil,
-         placeListCView : PlaceListCollectionView? =  nil,
+    init(placesListViewModel: PlacesListViewModelProtocol,
+         filterCView: FilterCollectionView? = nil,
+         placesListCView: PlacesListCollectionView? = nil,
          selectedPlaces: [PlaceItem],
          selectedCity: String,
          placeType: String){
-        self.placeListViewModel = placeListViewModel
-        self.filterCView = filterCView ?? FilterCollectionView(viewModel : placeListViewModel)
-        self.placeListCView = placeListCView ?? PlaceListCollectionView(viewModel : placeListViewModel)
+        self.placesListViewModel = placesListViewModel
+        self.filterCView = filterCView ?? FilterCollectionView(viewModel: placesListViewModel)
+        self.placesListCView = placesListCView ?? PlacesListCollectionView(viewModel: placesListViewModel)
         self.selectedPlaces = selectedPlaces
         self.selectedCity = selectedCity
         self.placeType = placeType
@@ -75,7 +75,7 @@ class PlacesListViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        placeListCView.delegate = self
+        placesListCView.delegate = self
         filterCView.delegate = self
         //setup()
     }
@@ -105,13 +105,13 @@ extension PlacesListViewController{
     
     func setCollectionViews(){
         filterCView.updateData(type: placeType)
-        placeListCView.updateData(for: selectedPlaces, by: placeType)
+        placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
     
     func addsubviews() {
         //self.view.backgroundColor  = UIColor(hex: "F0F8FF")
         filterCView.backgroundColor = .clear
-        placeListCView.backgroundColor = .clear
+        placesListCView.backgroundColor = .clear
         let backButton = UIBarButtonItem(image: UIImage(named: "nav-arrow-left"), style: .plain, target: self, action: #selector(didTapBack))
         backButton.tintColor = UIColor.black
 
@@ -125,15 +125,15 @@ extension PlacesListViewController{
         self.stackView.translatesAutoresizingMaskIntoConstraints = false
         
         stackView.addArrangedSubview(filterCView)
-        stackView.addArrangedSubview(placeListCView)
-        
+        stackView.addArrangedSubview(placesListCView)
+
         filterCView.translatesAutoresizingMaskIntoConstraints = false
-        placeListCView.translatesAutoresizingMaskIntoConstraints = false
+        placesListCView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     func setupConstraints() {
         
-        collectionViewHeightConstraint = placeListCView.heightAnchor.constraint(equalToConstant: 200)
+        collectionViewHeightConstraint = placesListCView.heightAnchor.constraint(equalToConstant: 200)
         NSLayoutConstraint.activate([
             mainScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             mainScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -163,8 +163,8 @@ extension PlacesListViewController{
 }
 
 //MARK: - UICollectionViewDelegate Methods
-extension PlacesListViewController: PlaceListCollectionViewDelegate {
-    func placeListCViewDidFailToLoadImage(_ collectionView: PlaceListCollectionView, error: any Error) {
+extension PlacesListViewController: PlacesListCollectionViewDelegate {
+    func placesListCollectionViewDidFailToLoadImage(_ collectionView: PlacesListCollectionView, error: any Error) {
         showAlert(title: "Error de Imagen", message: "No se pudo cargar la imagen. Intente nuevamente mas tarde")
     }
     
@@ -192,7 +192,7 @@ extension PlacesListViewController: FilterCollectionViewDelegate {
     func didSelectFilter(_ filter: DiscoverItem) {
         self.placeType = filter.name
         filterCView.updateData(type: placeType)
-        placeListCView.updateData(for: selectedPlaces, by: placeType)
+        placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
     
 }

--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
@@ -13,10 +13,10 @@ protocol FilterCollectionViewDelegate: AnyObject {
 
 class FilterCollectionView: UIView{
     
-    private var viewModel: PlaceListViewModelProtocol
+    private var viewModel: PlacesListViewModelProtocol
     weak var delegate: FilterCollectionViewDelegate?
     
-    init(viewModel: PlaceListViewModelProtocol, frame: CGRect = .zero) {
+    init(viewModel: PlacesListViewModelProtocol, frame: CGRect = .zero) {
         self.viewModel = viewModel
         super.init(frame: frame)
         setup()

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
@@ -1,5 +1,5 @@
 //
-//  PlaceListCollectionView.swift
+//  PlacesListCollectionView.swift
 //  PesoBlueMVVM
 //
 //  Created by Daniel Carcacha on 21/01/2025.
@@ -9,17 +9,17 @@ import Foundation
 import UIKit
 import CoreLocation
 
-protocol PlaceListCollectionViewDelegate: AnyObject {
+protocol PlacesListCollectionViewDelegate: AnyObject {
     func didUpdateItemCount(_ count: Int)
     func didSelectItem(_ item: PlaceItem)
-    func placeListCViewDidFailToLoadImage(_ collectionView: PlaceListCollectionView, error: Error)
+    func placesListCollectionViewDidFailToLoadImage(_ collectionView: PlacesListCollectionView, error: Error)
 }
 
-class PlaceListCollectionView: UIView{
-    
-    var viewModel : PlaceListViewModelProtocol
-    
-    init(viewModel: PlaceListViewModelProtocol, frame: CGRect = .zero) {
+class PlacesListCollectionView: UIView {
+
+    var viewModel: PlacesListViewModelProtocol
+
+    init(viewModel: PlacesListViewModelProtocol, frame: CGRect = .zero) {
         self.viewModel = viewModel
         super.init(frame: frame)
         setup()
@@ -36,7 +36,7 @@ class PlaceListCollectionView: UIView{
     
     var placeData: [PlaceItem] = []
     private let locationManager = LocationManager()
-    weak var delegate: PlaceListCollectionViewDelegate?
+    weak var delegate: PlacesListCollectionViewDelegate?
     var selectedIndex: IndexPath?
     
     
@@ -91,7 +91,7 @@ class PlaceListCollectionView: UIView{
 
 //MARK: - UICollectionViewDataSource Methods
 
-extension PlaceListCollectionView: UICollectionViewDataSource{
+extension PlacesListCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         placeData.count
     }
@@ -124,7 +124,7 @@ extension PlaceListCollectionView: UICollectionViewDataSource{
 //MARK: - UICOllectionViewDelegate Methods
 
 
-extension PlaceListCollectionView: UICollectionViewDelegate{
+extension PlacesListCollectionView: UICollectionViewDelegate {
    
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let item: PlaceItem = placeData[indexPath.item]
@@ -134,7 +134,7 @@ extension PlaceListCollectionView: UICollectionViewDelegate{
 
 //MARK: - Setup and Constraints
 
-extension PlaceListCollectionView{
+extension PlacesListCollectionView {
     
     func setup(){
         self.backgroundColor = .clear
@@ -161,9 +161,9 @@ extension PlaceListCollectionView{
     }
 }
 
-extension PlaceListCollectionView: PlaceCellDelegate{
+extension PlacesListCollectionView: PlaceCellDelegate {
     func placeCellDidFailToLoadImage(_ cell: PlaceCell, error: any Error) {
-        delegate?.placeListCViewDidFailToLoadImage(self, error: error)
+        delegate?.placesListCollectionViewDidFailToLoadImage(self, error: error)
     }
     
     

--- a/Pesoblu/Modules/PlacesList/ViewModel/PlacesListViewModel.swift
+++ b/Pesoblu/Modules/PlacesList/ViewModel/PlacesListViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  PlaceListViewModel.swift
+//  PlacesListViewModel.swift
 //  PesoBlueMVVM
 //
 //  Created by Daniel Carcacha on 20/01/2025.
@@ -8,13 +8,13 @@ import Foundation
 import UIKit
 import CoreLocation
 
-protocol PlaceListViewModelProtocol{
+protocol PlacesListViewModelProtocol {
     func getDistanceForPlace(_ place: PlaceItem) -> String
     func calculateDistance(from userLocation: CLLocation, to place: PlaceItem) -> String
     func filterData(places: [PlaceItem], filter: String) -> [PlaceItem]
     func fetchFilterItems() -> [DiscoverItem]
 }
-class PlaceListViewModel: PlaceListViewModelProtocol{
+class PlacesListViewModel: PlacesListViewModelProtocol {
     
     private let distanceService: DistanceServiceProtocol
     private let filterDataService: FilterDataServiceProtocol


### PR DESCRIPTION
## Summary
- standardize PlacesList module names across coordinator, view, and view model layers
- update collection and filter views to use PlacesList view model protocol
- adjust Home coordinator and Xcode breakpoint paths for renamed files

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6892b20a08d8833386083950feb41fea