### PR TITLE
Restrict internal view controller properties

### DIFF
--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -12,12 +12,12 @@ import CoreData
 class PlacesListViewController: UIViewController {
     
     var onSelect: ((PlaceItem) -> Void)?
-    var filterCView: FilterCollectionView
-    var placesListCView: PlacesListCollectionView
+    private let filterCView: FilterCollectionView
+    private let placesListCView: PlacesListCollectionView
     var placesListViewModel: PlacesListViewModelProtocol
-    var selectedPlaces: [PlaceItem]
-    var selectedCity: String
-    var placeType: String
+    private let selectedPlaces: [PlaceItem]
+    private let selectedCity: String
+    private(set) var placeType: String
     
     init(placesListViewModel: PlacesListViewModelProtocol,
          filterCView: FilterCollectionView? = nil,
@@ -39,7 +39,7 @@ class PlacesListViewController: UIViewController {
     }
     
     
-    var collectionViewHeightConstraint: NSLayoutConstraint!
+    private var collectionViewHeightConstraint: NSLayoutConstraint!
     
     private var mainScrollView: UIScrollView = {
         var scrollView = UIScrollView()


### PR DESCRIPTION
## Summary
- limit access to PlacesListViewController's collection views and selection state
- hide internal constraint for places list layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689495c7c28c83338decb138a9325751