### PR TITLE
Refactor PlacesList screen to use dedicated view

### DIFF
--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -10,80 +10,53 @@ import Foundation
 import CoreData
 
 class PlacesListViewController: UIViewController {
-    
+
     var onSelect: ((PlaceItem) -> Void)?
-    private let filterCView: FilterCollectionView
-    private let placesListCView: PlacesListCollectionView
     var placesListViewModel: PlacesListViewModelProtocol
     private let selectedPlaces: [PlaceItem]
     private let selectedCity: String
     private(set) var placeType: String
-    
+
+    private var placesListView: PlacesListView {
+        return view as! PlacesListView
+    }
+
     init(placesListViewModel: PlacesListViewModelProtocol,
-         filterCView: FilterCollectionView? = nil,
-         placesListCView: PlacesListCollectionView? = nil,
          selectedPlaces: [PlaceItem],
          selectedCity: String,
-         placeType: String){
+         placeType: String) {
         self.placesListViewModel = placesListViewModel
-        self.filterCView = filterCView ?? FilterCollectionView(viewModel: placesListViewModel)
-        self.placesListCView = placesListCView ?? PlacesListCollectionView(viewModel: placesListViewModel)
         self.selectedPlaces = selectedPlaces
         self.selectedCity = selectedCity
         self.placeType = placeType
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
-    private var collectionViewHeightConstraint: NSLayoutConstraint!
-    
-    private var mainScrollView: UIScrollView = {
-        var scrollView = UIScrollView()
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.showsHorizontalScrollIndicator = false
-        scrollView.showsVerticalScrollIndicator = true
-        scrollView.bounces = true
-        
-        return scrollView
-    }()
-    
-    private var contentView: UIView = {
-        var view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return view
-    }()
-    
-    private var stackView: UIStackView = {
-        var stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.distribution = .fill
-        stackView.spacing = 16
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        return stackView
-    }()
-    
+
     override func loadView() {
-        
-        self.view = UIView()
+        let filterView = FilterCollectionView(viewModel: placesListViewModel)
+        let placesView = PlacesListCollectionView(viewModel: placesListViewModel)
+        self.view = PlacesListView(filterCView: filterView, placesListCView: placesView)
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        placesListCView.delegate = self
-        filterCView.delegate = self
-        //setup()
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.title = "Lista de Lugares"
+        let backButton = UIBarButtonItem(image: UIImage(named: "nav-arrow-left"), style: .plain, target: self, action: #selector(didTapBack))
+        backButton.tintColor = .black
+        navigationItem.leftBarButtonItem = backButton
+
+        placesListView.placesListCView.delegate = self
+        placesListView.filterCView.delegate = self
+        setCollectionViews()
     }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if mainScrollView.superview == nil {
-            setup()
-        }
         view.applyVerticalGradientBackground(colors: [
             UIColor(red: 236/255, green: 244/255, blue: 255/255, alpha: 1),
             UIColor(red: 213/255, green: 229/255, blue: 252/255, alpha: 1)
@@ -91,114 +64,48 @@ class PlacesListViewController: UIViewController {
     }
 }
 
-//MARK: - AddSubViews and Setup Constraints and Set Collection Views Data
-
-extension PlacesListViewController{
-    
-    func setup(){
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationItem.title = "Lista de Lugares"
-        addsubviews()
-        setupConstraints()
-        setCollectionViews()
+extension PlacesListViewController {
+    func setCollectionViews() {
+        placesListView.filterCView.updateData(type: placeType)
+        placesListView.placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
-    
-    func setCollectionViews(){
-        filterCView.updateData(type: placeType)
-        placesListCView.updateData(for: selectedPlaces, by: placeType)
-    }
-    
-    func addsubviews() {
-        //self.view.backgroundColor  = UIColor(hex: "F0F8FF")
-        filterCView.backgroundColor = .clear
-        placesListCView.backgroundColor = .clear
-        let backButton = UIBarButtonItem(image: UIImage(named: "nav-arrow-left"), style: .plain, target: self, action: #selector(didTapBack))
-        backButton.tintColor = UIColor.black
-
-        self.navigationItem.leftBarButtonItem = backButton
-        view.addSubview(mainScrollView)
-        mainScrollView.addSubview(contentView)
-        contentView.addSubview(stackView)
-        
-        self.mainScrollView.translatesAutoresizingMaskIntoConstraints = false
-        self.contentView.translatesAutoresizingMaskIntoConstraints = false
-        self.stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        stackView.addArrangedSubview(filterCView)
-        stackView.addArrangedSubview(placesListCView)
-
-        filterCView.translatesAutoresizingMaskIntoConstraints = false
-        placesListCView.translatesAutoresizingMaskIntoConstraints = false
-    }
-    
-    func setupConstraints() {
-        
-        collectionViewHeightConstraint = placesListCView.heightAnchor.constraint(equalToConstant: 200)
-        NSLayoutConstraint.activate([
-            mainScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            mainScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            mainScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            mainScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-            contentView.topAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.topAnchor),
-            contentView.leadingAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.leadingAnchor, constant: 10),
-            contentView.trailingAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.trailingAnchor, constant: -10),
-            contentView.widthAnchor.constraint(equalTo: mainScrollView.frameLayoutGuide.widthAnchor, constant: -20),
-            contentView.bottomAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.bottomAnchor),
-
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            stackView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
-
-            filterCView.heightAnchor.constraint(equalToConstant: 142),
-            collectionViewHeightConstraint
-        ])
-        let heightConstraint = contentView.heightAnchor.constraint(equalTo: mainScrollView.frameLayoutGuide.heightAnchor)
-        heightConstraint.priority = UILayoutPriority.defaultLow
-        heightConstraint.isActive = true
-    }
-    
 }
 
-//MARK: - UICollectionViewDelegate Methods
+//MARK: - PlacesListCollectionViewDelegate
 extension PlacesListViewController: PlacesListCollectionViewDelegate {
     func placesListCollectionViewDidFailToLoadImage(_ collectionView: PlacesListCollectionView, error: any Error) {
         showAlert(title: "Error de Imagen", message: "No se pudo cargar la imagen. Intente nuevamente mas tarde")
     }
-    
+
     func didSelectItem(_ item: PlaceItem) {
         onSelect?(item)
     }
-    
+
     func didUpdateItemCount(_ count: Int) {
         let labelSpacing = 38.0
         let rows = ceil(Double(count))
         let itemHeight = 278.0
         let spacing = 10.0
         let totalHeight = rows * itemHeight + (rows - 1) * spacing + labelSpacing
-        collectionViewHeightConstraint.constant = totalHeight
-        
+        placesListView.collectionViewHeightConstraint.constant = totalHeight
+
         DispatchQueue.main.async {
             self.view.layoutIfNeeded()
         }
     }
 }
 
-//MARK: - FilterCollectionViewDelegate Methods
-
+//MARK: - FilterCollectionViewDelegate
 extension PlacesListViewController: FilterCollectionViewDelegate {
     func didSelectFilter(_ filter: DiscoverItem) {
         self.placeType = filter.name
-        filterCView.updateData(type: placeType)
-        placesListCView.updateData(for: selectedPlaces, by: placeType)
+        placesListView.filterCView.updateData(type: placeType)
+        placesListView.placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
-    
 }
-//MARK: - Alert Methods
 
-extension PlacesListViewController{
+//MARK: - Alert Methods
+extension PlacesListViewController {
     func showAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
@@ -207,10 +114,9 @@ extension PlacesListViewController{
 }
 
 //MARK: - Button Methods
-extension PlacesListViewController{
-    
+extension PlacesListViewController {
     @objc func didTapBack() {
-        // Regresar a la vista anterior
         navigationController?.popViewController(animated: true)
     }
 }
+

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListView/PlacesListView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListView/PlacesListView.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+class PlacesListView: UIView {
+
+    let filterCView: FilterCollectionView
+    let placesListCView: PlacesListCollectionView
+
+    private let mainScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = true
+        scrollView.bounces = true
+        return scrollView
+    }()
+
+    private let contentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.distribution = .fill
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    let collectionViewHeightConstraint: NSLayoutConstraint
+
+    init(filterCView: FilterCollectionView, placesListCView: PlacesListCollectionView) {
+        self.filterCView = filterCView
+        self.placesListCView = placesListCView
+        self.collectionViewHeightConstraint = placesListCView.heightAnchor.constraint(equalToConstant: 200)
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        addSubview(mainScrollView)
+        mainScrollView.addSubview(contentView)
+        contentView.addSubview(stackView)
+
+        stackView.addArrangedSubview(filterCView)
+        stackView.addArrangedSubview(placesListCView)
+
+        filterCView.translatesAutoresizingMaskIntoConstraints = false
+        placesListCView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            mainScrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            mainScrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mainScrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mainScrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            contentView.topAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.leadingAnchor, constant: 10),
+            contentView.trailingAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.trailingAnchor, constant: -10),
+            contentView.widthAnchor.constraint(equalTo: mainScrollView.frameLayoutGuide.widthAnchor, constant: -20),
+            contentView.bottomAnchor.constraint(equalTo: mainScrollView.contentLayoutGuide.bottomAnchor),
+
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+
+            filterCView.heightAnchor.constraint(equalToConstant: 142),
+            collectionViewHeightConstraint
+        ])
+
+        let heightConstraint = contentView.heightAnchor.constraint(equalTo: mainScrollView.frameLayoutGuide.heightAnchor)
+        heightConstraint.priority = .defaultLow
+        heightConstraint.isActive = true
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `PlacesListView` with scroll and stack layouts for filter and places collections
- refactor `PlacesListViewController` to use `PlacesListView` as root view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project Pesoblu.xcodeproj -scheme Pesoblu -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6894d5b9085083339f840fd5326c942e