### PR TITLE
Refactor filter view to accept provided items

### DIFF
--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -16,6 +16,7 @@ class PlacesListViewController: UIViewController {
     private let selectedPlaces: [PlaceItem]
     private let selectedCity: String
     private(set) var placeType: String
+    private var filters: [DiscoverItem] = []
 
     private var placesListView: PlacesListView {
         return view as! PlacesListView
@@ -37,7 +38,7 @@ class PlacesListViewController: UIViewController {
     }
 
     override func loadView() {
-        let filterView = FilterCollectionView(viewModel: placesListViewModel)
+        let filterView = FilterCollectionView()
         let placesView = PlacesListCollectionView(viewModel: placesListViewModel)
         self.view = PlacesListView(filterCView: filterView, placesListCView: placesView)
     }
@@ -66,7 +67,8 @@ class PlacesListViewController: UIViewController {
 
 extension PlacesListViewController {
     func setCollectionViews() {
-        placesListView.filterCView.updateData(type: placeType)
+        filters = placesListViewModel.fetchFilterItems()
+        placesListView.filterCView.update(with: filters, selectedType: placeType)
         placesListView.placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
 }
@@ -99,7 +101,7 @@ extension PlacesListViewController: PlacesListCollectionViewDelegate {
 extension PlacesListViewController: FilterCollectionViewDelegate {
     func didSelectFilter(_ filter: DiscoverItem) {
         self.placeType = filter.name
-        placesListView.filterCView.updateData(type: placeType)
+        placesListView.filterCView.update(with: filters, selectedType: placeType)
         placesListView.placesListCView.updateData(for: selectedPlaces, by: placeType)
     }
 }

--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
@@ -12,28 +12,26 @@ protocol FilterCollectionViewDelegate: AnyObject {
 }
 
 class FilterCollectionView: UIView{
-    
-    private var viewModel: PlacesListViewModelProtocol
+
     weak var delegate: FilterCollectionViewDelegate?
-    
-    init(viewModel: PlacesListViewModelProtocol, frame: CGRect = .zero) {
-        self.viewModel = viewModel
+
+    override init(frame: CGRect = .zero) {
         super.init(frame: frame)
         setup()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private var data: [DiscoverItem] = []
     private var placeType: String?
     private var selectedIndexPath: IndexPath?
-    private var previousIndexPath: IndexPath?
-    
-    func updateData(type: String){
-        placeType = type
-        self.data = viewModel.fetchFilterItems()
+
+    func update(with items: [DiscoverItem], selectedType: String){
+        data = items
+        placeType = selectedType
+        selectedIndexPath = nil
         filterCollectionView.reloadData()
     }
     


### PR DESCRIPTION
## Summary
- Refactor FilterCollectionView to drop ViewModel dependency and refresh via `update(with:selectedType:)`
- Load filter items in PlacesListViewController through PlacesListViewModel and supply them to the view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894d85967988333976e4c089a689419