### PR TITLE
Use weak self in PlaceViewController tasks

### DIFF
--- a/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
+++ b/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
@@ -194,25 +194,27 @@ extension PlaceViewController{
     }
     
     func loadFavoriteStatus() {
-        
-        Task{
-            do{
+
+        Task { [weak self] in
+            guard let self = self else { return }
+            do {
                 self.isFavorite = try await self.placeViewModel.loadFavoriteStatus()
             }
-            catch{
+            catch {
                 self.showAlert(title: "Error", message: "\(error.localizedDescription)")
             }
         }
     }
-    
+
     func saveFavoriteStatus(){
-        
-        Task{
-            do{
-                try await placeViewModel.saveFavoriteStatus(isFavorite: isFavorite)
+
+        Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                try await self.placeViewModel.saveFavoriteStatus(isFavorite: self.isFavorite)
             }
-            catch{
-                showAlert(title: "Error", message: "Error saving favorite status: \(error.localizedDescription)")
+            catch {
+                self.showAlert(title: "Error", message: "Error saving favorite status: \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
## Summary
- capture `self` weakly in `loadFavoriteStatus` and `saveFavoriteStatus`
- guard against deallocated view controller inside async tasks

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f13d01d88333bf2a9ced5125ae55