### PR TITLE
Mark storyboard initializers unavailable

### DIFF
--- a/Pesoblu/Modules/Change/View/ChangeViewController.swift
+++ b/Pesoblu/Modules/Change/View/ChangeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ChangeViewController: UIViewController {
+class ChangeViewController: UIViewController  {
     
     private var viewModel : ChangeViewModelProtocol
     private var changeCView: ChangeCollectionView
@@ -21,8 +21,10 @@ class ChangeViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     private var mainScrollView: UIScrollView = {
@@ -61,8 +63,8 @@ class ChangeViewController: UIViewController {
 
 //MARK: - Setup CollectionView
 
-private extension ChangeViewController{
-    func setup(){
+private extension ChangeViewController {
+    func setup() {
         
         self.view.backgroundColor = UIColor(hex: "F0F8FF")
         
@@ -103,15 +105,15 @@ private extension ChangeViewController{
     }
 }
 
-extension ChangeViewController{
-    func setTitle(){
+extension ChangeViewController {
+    func setTitle() {
         title = "Cotización"
         navigationController?.navigationBar.prefersLargeTitles = false
     }
 }
 //MARK: - ChangeCollectionViewDelegate Methods
 
-extension ChangeViewController: ChangeCollectionViewDelegate{
+extension ChangeViewController: ChangeCollectionViewDelegate {
     func didSelectCurrency(for currencyItem: CurrencyItem) {
         print("didSelectCurrency \(currencyItem)")
         onSelectCurrency?(currencyItem)

--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
@@ -6,7 +6,7 @@
 //
 import UIKit
 
-class ChangeCell: UICollectionViewCell{
+class ChangeCell: UICollectionViewCell {
     
     private lazy var changeView = ChangeView()
     
@@ -15,17 +15,19 @@ class ChangeCell: UICollectionViewCell{
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
-    func set(currencyTitle: String, currencyLabel: String, valueBuy: String){
+    func set(currencyTitle: String, currencyLabel: String, valueBuy: String) {
         changeView.set(currencyTitle: currencyTitle,
                        currencyLabel: currencyLabel,
                        valueBuy: valueBuy)
     }
     
-    private func setup(){
+    private func setup() {
         contentView.backgroundColor = .clear
         changeView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(changeView)

--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
@@ -7,11 +7,11 @@
 import Foundation
 import UIKit
 
-protocol ChangeCollectionViewDelegate: AnyObject{
+protocol ChangeCollectionViewDelegate: AnyObject {
     func didSelectCurrency(for currencyItem: CurrencyItem)
 }
 
-class ChangeCollectionView: UIView {
+class ChangeCollectionView: UIView  {
     
     private var collectionView: UICollectionView
     private var viewModel: ChangeViewModelProtocol
@@ -19,7 +19,7 @@ class ChangeCollectionView: UIView {
     
     var onHeightChange: ((CGFloat) -> Void)?
     
-    init(viewModel: ChangeViewModelProtocol){
+    init(viewModel: ChangeViewModelProtocol) {
         self.viewModel = viewModel
         
         let layout = UICollectionViewFlowLayout()
@@ -32,16 +32,18 @@ class ChangeCollectionView: UIView {
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
 }
-extension ChangeCollectionView{
+extension ChangeCollectionView {
 
 }
-private extension ChangeCollectionView{
-    func setup(){
+private extension ChangeCollectionView {
+    func setup() {
         
         collectionView.register(ChangeCell.self, forCellWithReuseIdentifier: "ChangeCell")
         collectionView.backgroundColor = .clear
@@ -65,7 +67,7 @@ private extension ChangeCollectionView{
     }
 }
 
-extension ChangeCollectionView: ChangeViewModelDelegate{
+extension ChangeCollectionView: ChangeViewModelDelegate {
     func didFinish() {
         collectionView.reloadData()
         DispatchQueue.main.async{
@@ -81,7 +83,7 @@ extension ChangeCollectionView: ChangeViewModelDelegate{
 
 //MARK: - UICollectionView DataSource
 
-extension ChangeCollectionView: UICollectionViewDataSource{
+extension ChangeCollectionView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         viewModel.currencies.count
@@ -100,7 +102,7 @@ extension ChangeCollectionView: UICollectionViewDataSource{
     }
 }
 
-extension ChangeCollectionView: UICollectionViewDelegate{
+extension ChangeCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let currencyItem = viewModel.currencies[indexPath.item]
         delegate?.didSelectCurrency(for: currencyItem)

--- a/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ChangeView: UIView {
+class ChangeView: UIView  {
 
     private lazy var viewDolar: UIView = {
         var view = UIView()
@@ -95,11 +95,13 @@ class ChangeView: UIView {
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
-    func set(currencyTitle: String, currencyLabel: String, valueBuy: String){
+    func set(currencyTitle: String, currencyLabel: String, valueBuy: String) {
         currencyTitleLabel.text = currencyTitle
         let text = String(valueBuy)
         currencyValueLabel.text =  "$ \(text)"// este es el qie muestra el valor
@@ -107,14 +109,14 @@ class ChangeView: UIView {
     }
 }
 
-private extension ChangeView {
-    func setup(){
+private extension ChangeView  {
+    func setup() {
         
         addsubviews()
         setupConstraints()
     }
     
-    private func addsubviews(){
+    private func addsubviews() {
         self.backgroundColor = .clear
         self.layer.cornerRadius = 10
         self.addSubview(viewDolar)

--- a/Pesoblu/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
+++ b/Pesoblu/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Combine
 import UserNotifications
 
-final class CurrencyConverterViewController: UIViewController {
+final class CurrencyConverterViewController: UIViewController  {
     
     private var cancellables = Set<AnyCancellable>()
     let viewModel: CurrencyConverterViewModelProtocol
@@ -30,8 +30,10 @@ final class CurrencyConverterViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     override func loadView() {
@@ -56,9 +58,9 @@ final class CurrencyConverterViewController: UIViewController {
         }
     }
 }
-extension CurrencyConverterViewController{
+extension CurrencyConverterViewController {
     
-    func setup(){
+    func setup() {
         title = "Convertir"
         navigationController?.navigationBar.prefersLargeTitles = false
         let backButton = UIBarButtonItem(image: UIImage(named: "nav-arrow-left"), style: .plain, target: self, action: #selector(didTapBack))
@@ -76,9 +78,9 @@ extension CurrencyConverterViewController{
 
 //MARK: - Local Notifications
 
-extension CurrencyConverterViewController{
+extension CurrencyConverterViewController {
     
-    func startTimer(){
+    func startTimer() {
         Timer.scheduledTimer(withTimeInterval: 6000, repeats: true) { timer in
             Task{
                 if let dolar = try await self.viewModel.getDolarBlue() {
@@ -92,7 +94,7 @@ extension CurrencyConverterViewController{
 //#Preview("CurrencyViewController", traits: .defaultLayout, body: { CurrencyViewController()})
 
 //MARK: - Button Methods
-extension CurrencyConverterViewController{
+extension CurrencyConverterViewController {
     
     @objc func didTapBack() {
         // Regresar a la vista anterior
@@ -101,7 +103,7 @@ extension CurrencyConverterViewController{
 }
 
 // MARK: - Bindings
-extension CurrencyConverterViewController {
+extension CurrencyConverterViewController  {
     func setupBindings() {
         viewModel.getConvertedValues()
             .receive(on: DispatchQueue.main)

--- a/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyConverterView.swift
+++ b/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyConverterView.swift
@@ -10,7 +10,7 @@ import Combine
 
 ///una vez que sea funcional subir el titilelabel arriba y el valuelabel bajarlo asi no se chocan los caracteres, y darle colores a los distintos caracteres para que no sea aburrido
 
-final class CurrencyConverterView: UIView {
+final class CurrencyConverterView: UIView  {
         
     var onAmountChanged: ((Double?) -> Void)?
     private var selectedCurrency: String = ""
@@ -221,11 +221,11 @@ final class CurrencyConverterView: UIView {
         self.endEditing(true)
     }
     
-    func resigncurrencytext(){
+    func resigncurrencytext() {
         currencyLabel.resignFirstResponder()
     }
     
-    func resignQuantityText(){
+    func resignQuantityText() {
         quantitytextfield.resignFirstResponder()
     }
     
@@ -236,8 +236,10 @@ final class CurrencyConverterView: UIView {
         toDolarValue.text = toDolar
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     private func setupGradientBackground() {
@@ -277,16 +279,16 @@ final class CurrencyConverterView: UIView {
 
 //MARK: - Setup and Constraints Methods
 
-private extension CurrencyConverterView{
+private extension CurrencyConverterView {
     
-    func setup(){
+    func setup() {
         addsubviews()
         setupconstraints()
         setupAmountBinding()
         
     }
     
-    private func addsubviews(){
+    private func addsubviews() {
         
         self.backgroundColor = .white
         
@@ -317,7 +319,7 @@ private extension CurrencyConverterView{
         quantitytextfield.addTarget(self, action: #selector(amountTextChanged), for: .editingChanged)
     }
     
-    private func setupconstraints(){
+    private func setupconstraints() {
         
         NSLayoutConstraint.activate([
             
@@ -394,7 +396,7 @@ private extension CurrencyConverterView{
 
 //MARK: - TextField & PickerView Methods
 
-extension CurrencyConverterView: UITextFieldDelegate{
+extension CurrencyConverterView: UITextFieldDelegate {
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
@@ -432,9 +434,9 @@ extension CurrencyConverterView: UITextFieldDelegate{
 
 //MARK: - Reset Controls
 
-extension CurrencyConverterView{
+extension CurrencyConverterView {
     
-    func resetControls(){
+    func resetControls() {
         toPesoValue.text = "0.00"
         fromPesoValue.text = "0.00"
         toDolarValue.text = "0.00"
@@ -445,9 +447,9 @@ extension CurrencyConverterView{
 
 //MARK: - Set Currency Methods
 
-extension CurrencyConverterView{
+extension CurrencyConverterView {
     
-    func setCurrency(currency: CurrencyItem){
+    func setCurrency(currency: CurrencyItem) {
         currencyLabel.text = currency.currencyTitle
         currencyLabel.textColor = .black
         currencyLabel.font = .systemFont(ofSize: 18, weight: .semibold)
@@ -456,7 +458,7 @@ extension CurrencyConverterView{
         setTitleLabels(currency: currency)
     }
     
-    func setTitleLabels(currency: CurrencyItem){
+    func setTitleLabels(currency: CurrencyItem) {
         selectedCurrency = currency.currencyLabel ?? ""
         switch currency.currencyLabel {
         case "Uruguay":

--- a/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyRowView.swift
+++ b/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyRowView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ConversionRowView: UIView {
+final class ConversionRowView: UIView  {
     
     private lazy var buyview: UIView = {
         var view = UIView()
@@ -45,8 +45,10 @@ final class ConversionRowView: UIView {
         configure(title: title, value: value)
     }
 
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     private func setupUI() {

--- a/Pesoblu/Modules/Home/View/HomeViewController.swift
+++ b/Pesoblu/Modules/Home/View/HomeViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class HomeViewController: UIViewController {
+final class HomeViewController: UIViewController  {
     
     var quickConversorView : QuickConversorView
     var discoverBaCView : DiscoverBaCollectionView
@@ -32,8 +32,10 @@ final class HomeViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-            fatalError(NSLocalizedString("init_coder_not_implemented", comment: ""))
+        return nil
     }
     
     private var mainScrollView: UIScrollView = {
@@ -93,7 +95,7 @@ final class HomeViewController: UIViewController {
 
 //MARK: - Setting the View
 @MainActor
-extension HomeViewController {
+extension HomeViewController  {
     func setup() {
         setupUI()
         citysCView.delegate = self
@@ -105,9 +107,9 @@ extension HomeViewController {
 
 //MARK: - Setup SubViews and Constraints
 @MainActor
-extension HomeViewController{
+extension HomeViewController {
     
-    func setupUI(){
+    func setupUI() {
         title = NSLocalizedString("home_title", comment: "")
         self.navigationController?.navigationBar.prefersLargeTitles = true
         extendedLayoutIncludesOpaqueBars = true
@@ -119,7 +121,7 @@ extension HomeViewController{
         
     }
     
-    func addSubViews(){
+    func addSubViews() {
         self.view.backgroundColor = UIColor(hex: "F0F8FF")
         view.addSubview(mainScrollView)
         mainScrollView.addSubview(contentView)
@@ -129,7 +131,7 @@ extension HomeViewController{
         stackView.addArrangedSubview(quickConversorView)
     }
     
-    func addConstraints(){
+    func addConstraints() {
         //collectionViewHeightConstraint = citysCView.heightAnchor.constraint(equalToConstant: 200) // Altura inicial
         NSLayoutConstraint.activate([
             
@@ -178,8 +180,8 @@ extension HomeViewController{
 
 //MARK: - SetUp QuickConversor
 @MainActor
-extension HomeViewController{
-    func setupQuickConversor(){
+extension HomeViewController {
+    func setupQuickConversor() {
         
         Task { @MainActor in
             do{
@@ -214,7 +216,7 @@ extension HomeViewController{
 }
 
 //MARK: - DiscoverCollectionViewDelegate Methods
-extension HomeViewController: CollectionViewSelectionDelegate{
+extension HomeViewController: CollectionViewSelectionDelegate {
     
     func didSelectItem(_ item: DiscoverItem) {
         do {
@@ -246,7 +248,7 @@ extension HomeViewController: CollectionViewSelectionDelegate{
 }
 
 //MARK: - CitysViewDelegate Methods
-extension HomeViewController: CitysViewDelegate{
+extension HomeViewController: CitysViewDelegate {
     func didSelectItem(_ city: CitysItem) {
         let selectedCity = String(city.name)
         

--- a/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCell.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class CitysCell: UICollectionViewCell {
+final class CitysCell: UICollectionViewCell  {
     
     // MARK: - Public Properties
     private lazy var imageView : UIImageView = {
@@ -30,7 +30,7 @@ final class CitysCell: UICollectionViewCell {
         return label
     }()
     
-    func set(image: String, title: String){
+    func set(image: String, title: String) {
         imageView.image = UIImage(named: image)
         titleLabel.text = title
     }
@@ -41,11 +41,13 @@ final class CitysCell: UICollectionViewCell {
         setupViews()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError(NSLocalizedString("init_coder_not_implemented", comment: ""))
+        return nil
     }
 }
-private extension CitysCell {
+private extension CitysCell  {
     
     private func setupViews() {
         addsubviews()
@@ -59,7 +61,7 @@ private extension CitysCell {
         contentView.addSubview(titleLabel)
     }
     
-    func setupConstraints(){
+    func setupConstraints() {
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),

--- a/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCollectionView.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCollectionView.swift
@@ -6,13 +6,13 @@
 //
 import UIKit
 
-protocol CitysViewDelegate: AnyObject{
+protocol CitysViewDelegate: AnyObject {
     func didUpdateItemCount(_ count: Int)
     func didSelectItem(_ city: CitysItem)
     
 }
 
-final class CitysCollectionView: UIView{
+final class CitysCollectionView: UIView {
     
     private var data: [CitysItem] = []
     private let homeViewModel: HomeViewModelProtocol  // Usamos el protocolo en lugar de la clase concreta
@@ -24,8 +24,10 @@ final class CitysCollectionView: UIView{
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError(NSLocalizedString("init_coder_not_implemented", comment: ""))
+        return nil
     }
     
     func updateData() {
@@ -71,7 +73,7 @@ final class CitysCollectionView: UIView{
 
 //MARK: - Setup Methods and Constraints
 
-extension CitysCollectionView{
+extension CitysCollectionView {
     
     func setup() {
         self.backgroundColor = .clear
@@ -94,7 +96,7 @@ extension CitysCollectionView{
 
 //MARK: - UICollectionViewDataSource Methods
 
-extension CitysCollectionView: UICollectionViewDataSource {
+extension CitysCollectionView: UICollectionViewDataSource  {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return data.count
     }
@@ -107,7 +109,7 @@ extension CitysCollectionView: UICollectionViewDataSource {
     }
 }
 
-extension CitysCollectionView: UICollectionViewDelegate{
+extension CitysCollectionView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedCity = data[indexPath.item]
         delegate?.didSelectItem(selectedCity)
@@ -115,7 +117,7 @@ extension CitysCollectionView: UICollectionViewDelegate{
 }
 
 
-extension CitysCollectionView {
+extension CitysCollectionView  {
     var collectionViewForTesting: UICollectionView {
         return citysCollectionView
     }

--- a/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverBaCollectionView.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverBaCollectionView.swift
@@ -8,11 +8,11 @@
 import UIKit
 import Kingfisher
 
-protocol CollectionViewSelectionDelegate: AnyObject {
+protocol CollectionViewSelectionDelegate: AnyObject  {
     func didSelectItem(_ item: DiscoverItem) // Define el tipo de datos que envías
 }
 
-final class DiscoverBaCollectionView: UIView {
+final class DiscoverBaCollectionView: UIView  {
     
     private var data: [DiscoverItem] = []
     private var homeViewModel : HomeViewModelProtocol
@@ -26,8 +26,10 @@ final class DiscoverBaCollectionView: UIView {
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError(NSLocalizedString("init_coder_not_implemented", comment: ""))
+        return nil
     }
     
     func setData() {
@@ -71,7 +73,7 @@ final class DiscoverBaCollectionView: UIView {
 
 //MARK: - UICollectionViewDataSource
 
-extension DiscoverBaCollectionView: UICollectionViewDataSource {
+extension DiscoverBaCollectionView: UICollectionViewDataSource  {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         data.count
     }
@@ -87,7 +89,7 @@ extension DiscoverBaCollectionView: UICollectionViewDataSource {
 
 //MARK: - UICollectionViewDelegate Methods
 
-extension DiscoverBaCollectionView: UICollectionViewDelegate {
+extension DiscoverBaCollectionView: UICollectionViewDelegate  {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
@@ -98,7 +100,7 @@ extension DiscoverBaCollectionView: UICollectionViewDelegate {
     
 }
 
-private extension DiscoverBaCollectionView {
+private extension DiscoverBaCollectionView  {
     
     func setup() {
         self.backgroundColor = .clear
@@ -119,7 +121,7 @@ private extension DiscoverBaCollectionView {
     }
 }
 
-extension DiscoverBaCollectionView {
+extension DiscoverBaCollectionView  {
     var collectionViewForTesting: UICollectionView {
         return discoverCollectionView
     }

--- a/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverCell.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class DiscoverCell: UICollectionViewCell {
+final class DiscoverCell: UICollectionViewCell  {
     
     // MARK: - Public Properties
     private lazy var imageView : UIImageView = {
@@ -30,7 +30,7 @@ final class DiscoverCell: UICollectionViewCell {
         return label
     }()
     
-    func set(image: String, title: String){
+    func set(image: String, title: String) {
         imageView.image = UIImage(named: image)
         titleLabel.text = title
     }
@@ -41,11 +41,13 @@ final class DiscoverCell: UICollectionViewCell {
         setupViews()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError(NSLocalizedString("init_coder_not_implemented", comment: ""))
+        return nil
     }
 }
-private extension DiscoverCell {
+private extension DiscoverCell  {
     
     private func setupViews() {
         
@@ -62,7 +64,7 @@ private extension DiscoverCell {
         contentView.addSubview(titleLabel)
     }
     
-    func setupConstraints(){
+    func setupConstraints() {
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),

--- a/Pesoblu/Modules/Login/View/LoginViewController.swift
+++ b/Pesoblu/Modules/Login/View/LoginViewController.swift
@@ -9,12 +9,12 @@ import UIKit
 import FirebaseAnalytics
 import Combine
 
-protocol LoginViewProtocol: AnyObject {
+protocol LoginViewProtocol: AnyObject  {
     func didTapSignUpGoogle() async
     func didTapSignUpApple()
 }
 
-class LoginViewController: UIViewController, LoginViewProtocol {
+class LoginViewController: UIViewController, LoginViewProtocol  {
     
     var authVM : AuthenticationViewModelProtocol
     let userService : UserService
@@ -31,8 +31,10 @@ class LoginViewController: UIViewController, LoginViewProtocol {
         super.init(nibName: nil, bundle: nil)
     }
     
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     override func loadView() {
@@ -103,7 +105,7 @@ class LoginViewController: UIViewController, LoginViewProtocol {
 
 //MARK: - Sign in Methods
 
-extension LoginViewController {
+extension LoginViewController  {
     
     func didTapSignUpGoogle() async {
         do {
@@ -127,7 +129,7 @@ extension LoginViewController {
     }
 }
 
-extension LoginViewController: AuthenticationDelegate{
+extension LoginViewController: AuthenticationDelegate {
     private func showErrorAlert(_ error: AuthenticationViewModel.AuthError) {
         let alert = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
@@ -144,7 +146,7 @@ extension LoginViewController: AuthenticationDelegate{
 
 }
 
-extension LoginViewController {
+extension LoginViewController  {
     static func create(authVM: AuthenticationViewModel,
                        userService: UserService,
                        coordinator: LoginNavigationDelegate) -> LoginViewController {

--- a/Pesoblu/Modules/Login/View/SubViews/LoginView.swift
+++ b/Pesoblu/Modules/Login/View/SubViews/LoginView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class LoginView: UIView {
+class LoginView: UIView  {
     
     private lazy var scrollView: UIScrollView = {
         var sview = UIScrollView()
@@ -214,13 +214,15 @@ class LoginView: UIView {
         setupUI()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
         
 }
 
-private extension LoginView{
+private extension LoginView {
      func setupUI() {
         self.backgroundColor = UIColor(red: 0.95, green: 0.97, blue: 0.98, alpha: 1.0)
         

--- a/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
+++ b/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
@@ -9,11 +9,11 @@ import UIKit
 import MapKit
 import CoreData
 
-protocol AlertPresenter {
+protocol AlertPresenter  {
     func present(on viewController: UIViewController, title: String, message: String)
 }
 
-struct DefaultAlertPresenter: AlertPresenter {
+struct DefaultAlertPresenter: AlertPresenter  {
     func present(on viewController: UIViewController, title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
@@ -21,7 +21,7 @@ struct DefaultAlertPresenter: AlertPresenter {
     }
 }
 
-final class PlaceViewController: UIViewController {
+final class PlaceViewController: UIViewController  {
 
     private lazy var placeView = PlaceView()
     private let placeViewModel: PlaceViewModelProtocol
@@ -43,8 +43,10 @@ final class PlaceViewController: UIViewController {
         setupDependencies()
     }
     
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     private var isFavorite: Bool = false {
@@ -83,7 +85,7 @@ final class PlaceViewController: UIViewController {
         setupUI()
     }
     
-    override func viewDidLayoutSubviews(){
+    override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         view.applyVerticalGradientBackground(colors: [
             UIColor(red: 236/255, green: 244/255, blue: 255/255, alpha: 1),
@@ -98,9 +100,9 @@ final class PlaceViewController: UIViewController {
 
 //MARK: - Setup Constraints
 
-extension PlaceViewController{
+extension PlaceViewController {
     
-    func setupDependencies(){
+    func setupDependencies() {
         placeView.delegate = self
     }
     
@@ -118,7 +120,7 @@ extension PlaceViewController{
         loadFavoriteStatus()
     }
     
-    func setupViews(){
+    func setupViews() {
         view.addSubview(scrollView)
         scrollView.addSubview(contentView)
         
@@ -155,7 +157,7 @@ extension PlaceViewController{
 
 //MARK: - Error Alerts
 
-extension PlaceViewController: PlaceViewDelegate{
+extension PlaceViewController: PlaceViewDelegate {
     func didFailToOpenMaps() {
         showAlert(title: "ERROR", message: "No se pudo abrir maps.")
     }
@@ -178,9 +180,9 @@ extension PlaceViewController: PlaceViewDelegate{
 //MARK: - Navigation and Methods Buttons
 
 
-extension PlaceViewController{
+extension PlaceViewController {
     
-    private func setupNavigationButton(){
+    private func setupNavigationButton() {
         // Asignar el botón como customView del UIBarButtonItem
         let barButtonItem = UIBarButtonItem(customView: favoriteButton)
         navigationItem.rightBarButtonItem = barButtonItem
@@ -206,7 +208,7 @@ extension PlaceViewController{
         }
     }
 
-    func saveFavoriteStatus(){
+    func saveFavoriteStatus() {
 
         Task { [weak self] in
             guard let self = self else { return }

--- a/Pesoblu/Modules/PlaceView/View/SubView/PlaceView.swift
+++ b/Pesoblu/Modules/PlaceView/View/SubView/PlaceView.swift
@@ -11,22 +11,24 @@ import MapKit
 import Kingfisher
 import CoreData
 
-protocol PlaceViewDelegate: AnyObject{
+protocol PlaceViewDelegate: AnyObject {
     func didFailToLoadImage(_ view: PlaceView, error: Error)
     func didFailToCall()
     func didFailToOpenInstagram(title: String, message: String)
     func didFailToOpenMaps()
 }
 
-final class PlaceView: UIView{
+final class PlaceView: UIView {
     
-    init(){
+    init() {
         super.init(frame: .zero)
         setup()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
     weak var delegate: PlaceViewDelegate?
@@ -121,7 +123,7 @@ final class PlaceView: UIView{
         return mapView
     }()
     
-    func setData(item: PlaceItem){
+    func setData(item: PlaceItem) {
         place = item
         nameLabel.text = item.name
         categoriesLabel.text = item.categories?.joined(separator: " · ")
@@ -196,7 +198,7 @@ final class PlaceView: UIView{
 
 //MARK: - TapGesture Methods
 
-extension PlaceView{
+extension PlaceView {
     
     @objc private func expandImage() {
         guard let superview = self.superview else { return }

--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Foundation
 import CoreData
 
-final class PlacesListViewController: UIViewController {
+final class PlacesListViewController: UIViewController  {
 
     var onSelect: ((PlaceItem) -> Void)?
     var placesListViewModel: PlacesListViewModelProtocol
@@ -35,8 +35,10 @@ final class PlacesListViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     override func loadView() {
@@ -67,7 +69,7 @@ final class PlacesListViewController: UIViewController {
     }
 }
 
-extension PlacesListViewController {
+extension PlacesListViewController  {
     func setCollectionViews() {
         filters = placesListViewModel.fetchFilterItems()
         placesListView.filterCView.update(with: filters, selectedType: placeType)
@@ -77,7 +79,7 @@ extension PlacesListViewController {
 }
 
 //MARK: - PlacesListCollectionViewDelegate
-extension PlacesListViewController: PlacesListCollectionViewDelegate {
+extension PlacesListViewController: PlacesListCollectionViewDelegate  {
     func placesListCollectionViewDidFailToLoadImage(_ collectionView: PlacesListCollectionView, error: any Error) {
         showAlert(title: "Error de Imagen", message: "No se pudo cargar la imagen. Intente nuevamente mas tarde")
     }
@@ -101,7 +103,7 @@ extension PlacesListViewController: PlacesListCollectionViewDelegate {
 }
 
 //MARK: - FilterCollectionViewDelegate
-extension PlacesListViewController: FilterCollectionViewDelegate {
+extension PlacesListViewController: FilterCollectionViewDelegate  {
     func didSelectFilter(_ filter: DiscoverItem) {
         guard let type = PlaceType(rawValue: filter.name) else { return }
         placeType = type
@@ -112,7 +114,7 @@ extension PlacesListViewController: FilterCollectionViewDelegate {
 }
 
 //MARK: - Alert Methods
-extension PlacesListViewController {
+extension PlacesListViewController  {
     func showAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
@@ -121,7 +123,7 @@ extension PlacesListViewController {
 }
 
 //MARK: - Button Methods
-extension PlacesListViewController {
+extension PlacesListViewController  {
     @objc func didTapBack() {
         navigationController?.popViewController(animated: true)
     }

--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCell.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCell.swift
@@ -6,7 +6,7 @@
 //
 import UIKit
 
-final class FilterCell: UICollectionViewCell{
+final class FilterCell: UICollectionViewCell {
     
     // MARK: - Properties
     private lazy var imageView : UIImageView = {
@@ -27,7 +27,7 @@ final class FilterCell: UICollectionViewCell{
         return label
     }()
     
-    func set(image: String, title: String){
+    func set(image: String, title: String) {
         imageView.image = UIImage(named: image)
         titleLabel.text = title
     }
@@ -37,20 +37,22 @@ final class FilterCell: UICollectionViewCell{
         setupViews()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
     
 }
 
-extension FilterCell{
+extension FilterCell {
     
-    func setupViews(){
+    func setupViews() {
         addSubViews()
         setupConstraints()
     }
     
-    func addSubViews(){
+    func addSubViews() {
         self.backgroundColor = .white
         self.layer.cornerRadius = 8.0
         self.layer.borderWidth = 1.0

--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-protocol FilterCollectionViewDelegate: AnyObject {
+protocol FilterCollectionViewDelegate: AnyObject  {
     func didSelectFilter(_ filter: DiscoverItem)
 }
 
-final class FilterCollectionView: UIView{
+final class FilterCollectionView: UIView {
 
     weak var delegate: FilterCollectionViewDelegate?
 
@@ -20,15 +20,17 @@ final class FilterCollectionView: UIView{
         setup()
     }
 
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     private var data: [DiscoverItem] = []
     private var placeType: PlaceType?
     private var selectedIndexPath: IndexPath?
 
-    func update(with items: [DiscoverItem], selectedType: PlaceType){
+    func update(with items: [DiscoverItem], selectedType: PlaceType) {
         data = items
         placeType = selectedType
         selectedIndexPath = nil
@@ -70,7 +72,7 @@ final class FilterCollectionView: UIView{
 
 //MARK: - UICollectionViewDataSource Methods
 
-extension FilterCollectionView: UICollectionViewDataSource{
+extension FilterCollectionView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         data.count
@@ -100,13 +102,13 @@ extension FilterCollectionView: UICollectionViewDataSource{
     
 }
 
-extension FilterCollectionView: UICollectionViewDelegateFlowLayout {
+extension FilterCollectionView: UICollectionViewDelegateFlowLayout  {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 100, height: 110)
     }
 }
 
-extension FilterCollectionView : UICollectionViewDelegate{
+extension FilterCollectionView : UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let previousIndexPath = selectedIndexPath
        
@@ -133,9 +135,9 @@ extension FilterCollectionView : UICollectionViewDelegate{
 
 //MARK: - Setup CollectionView Constraints
 
-extension FilterCollectionView{
+extension FilterCollectionView {
     
-    func setup(){
+    func setup() {
         self.backgroundColor = .clear
         addSubview(filterLabel)
         addSubview(filterCollectionView)

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlaceCell.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlaceCell.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-protocol PlaceCellDelegate: AnyObject {
+protocol PlaceCellDelegate: AnyObject  {
     func placeCellDidFailToLoadImage(_ cell: PlaceCell, error: Error)
 }
 
-final class PlaceCell: UICollectionViewCell {
+final class PlaceCell: UICollectionViewCell  {
     
     weak var delegate: PlaceCellDelegate?
     //MARK: - Properties
@@ -60,7 +60,7 @@ final class PlaceCell: UICollectionViewCell {
     //MARK: - Set Methods
     /// Configures the cell with the provided data. `formattedDistance` should
     /// already contain the distance string ready for display (e.g. "1.2 km").
-    func set(image: UIImage?, title: String, price: String, formattedDistance: String, type: String){
+    func set(image: UIImage?, title: String, price: String, formattedDistance: String, type: String) {
         placeImage.image = image
         placeName.text = title
         priceLabel.text = price
@@ -93,21 +93,23 @@ final class PlaceCell: UICollectionViewCell {
         setupViews()
     }
     
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 }
 
 //MARK: - Setup SubViews and Constraints Methods
 
-extension PlaceCell {
+extension PlaceCell  {
  
-    func setupViews(){
+    func setupViews() {
         addsubViews()
         setupConstraints()
     }
     
-    func addsubViews(){
+    func addsubViews() {
         self.backgroundColor = .white
         self.layer.cornerRadius = 10
         contentView.addSubview(placeImage)
@@ -117,7 +119,7 @@ extension PlaceCell {
         contentView.addSubview(distanceLabel)
     }
     
-    func setupConstraints(){
+    func setupConstraints() {
         
         NSLayoutConstraint.activate([
             placeImage.topAnchor.constraint(equalTo: contentView.topAnchor),

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
@@ -8,13 +8,13 @@
 import Foundation
 import UIKit
 
-protocol PlacesListCollectionViewDelegate: AnyObject {
+protocol PlacesListCollectionViewDelegate: AnyObject  {
     func didUpdateItemCount(_ count: Int)
     func didSelectItem(_ item: PlaceItem)
     func placesListCollectionViewDidFailToLoadImage(_ collectionView: PlacesListCollectionView, error: Error)
 }
 
-final class PlacesListCollectionView: UIView {
+final class PlacesListCollectionView: UIView  {
 
     var placeData: [PlaceItemViewModel] = []
     weak var delegate: PlacesListCollectionViewDelegate?
@@ -25,8 +25,10 @@ final class PlacesListCollectionView: UIView {
         setup()
     }
 
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     func updateData(with items: [PlaceItemViewModel]) {
@@ -74,7 +76,7 @@ final class PlacesListCollectionView: UIView {
 
 //MARK: - UICollectionViewDataSource Methods
 
-extension PlacesListCollectionView: UICollectionViewDataSource {
+extension PlacesListCollectionView: UICollectionViewDataSource  {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         placeData.count
     }
@@ -97,7 +99,7 @@ extension PlacesListCollectionView: UICollectionViewDataSource {
 //MARK: - UICOllectionViewDelegate Methods
 
 
-extension PlacesListCollectionView: UICollectionViewDelegate {
+extension PlacesListCollectionView: UICollectionViewDelegate  {
 
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let item: PlaceItem = placeData[indexPath.item].place
@@ -107,9 +109,9 @@ extension PlacesListCollectionView: UICollectionViewDelegate {
 
 //MARK: - Setup and Constraints
 
-extension PlacesListCollectionView {
+extension PlacesListCollectionView  {
     
-    func setup(){
+    func setup() {
         self.backgroundColor = .clear
         addSubview(quantityLabel)
         addSubview(placeCollectionView)
@@ -134,7 +136,7 @@ extension PlacesListCollectionView {
     }
 }
 
-extension PlacesListCollectionView: PlaceCellDelegate {
+extension PlacesListCollectionView: PlaceCellDelegate  {
     func placeCellDidFailToLoadImage(_ cell: PlaceCell, error: any Error) {
         delegate?.placesListCollectionViewDidFailToLoadImage(self, error: error)
     }

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListView/PlacesListView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListView/PlacesListView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class PlacesListView: UIView {
+class PlacesListView: UIView  {
 
     let filterCView: FilterCollectionView
     let placesListCView: PlacesListCollectionView
@@ -39,8 +39,10 @@ class PlacesListView: UIView {
         setup()
     }
 
+    /// This view is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 
     private func setup() {

--- a/Pesoblu/Modules/TabBar/PesoBlueTabBarController.swift
+++ b/Pesoblu/Modules/TabBar/PesoBlueTabBarController.swift
@@ -6,14 +6,16 @@
 //
 import UIKit
 
-class PesoBlueTabBarController: UITabBarController {
+class PesoBlueTabBarController: UITabBarController  {
 
     init(viewControllers: [UIViewController]) {
         super.init(nibName: nil, bundle: nil)
         self.viewControllers = viewControllers
     }
 
+    /// This view controller is intended to be instantiated programmatically.
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- Replace `fatalError` with `@available(*, unavailable)` in all `init?(coder:)` implementations
- Document that affected views and controllers are intended for programmatic use
- Normalize brace spacing and other minor style issues across updated files

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68962c4cebfc83339eff8e42d804516f