### PR TITLE
refactor: centralize layout constants

### DIFF
--- a/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCell.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCell.swift
@@ -15,7 +15,7 @@ final class CitysCell: UICollectionViewCell  {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
-        view.layer.cornerRadius = 8
+        view.layer.cornerRadius = LayoutConstants.containerCornerRadius
         view.clipsToBounds = true
         return view
     }()
@@ -23,7 +23,7 @@ final class CitysCell: UICollectionViewCell  {
     private lazy var titleLabel : UILabel = {
         var label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
+        label.font = UIFont.systemFont(ofSize: LayoutConstants.cityCellTitleFontSize, weight: .bold)
         label.numberOfLines = 0
         label.textColor = UIColor(named: "primaryTextColor") ?? .black
         label.textAlignment = .center
@@ -56,7 +56,7 @@ private extension CitysCell  {
     
     func addsubviews() {
         self.backgroundColor = .white
-        self.layer.cornerRadius = 10
+        self.layer.cornerRadius = LayoutConstants.cityCellCornerRadius
         contentView.addSubview(imageView)
         contentView.addSubview(titleLabel)
     }
@@ -66,12 +66,12 @@ private extension CitysCell  {
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            imageView.heightAnchor.constraint(equalToConstant: 100),
+            imageView.heightAnchor.constraint(equalToConstant: LayoutConstants.cityImageHeight),
 
-            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 5),
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
-            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
-            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5)
+            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: LayoutConstants.extraSmallPadding),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: LayoutConstants.edgePadding),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -LayoutConstants.edgePadding),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -LayoutConstants.extraSmallPadding)
         ])
     }
 }

--- a/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCollectionView.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/CitysCollectionView/CitysCollectionView.swift
@@ -40,7 +40,7 @@ final class CitysCollectionView: UIView {
     private lazy var discoverArgentinaLabel: UILabel = {
         let label = UILabel()
         label.textColor = .black
-        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.font = .systemFont(ofSize: LayoutConstants.sectionHeaderFontSize, weight: .semibold)
         label.textAlignment = .left
         label.text = NSLocalizedString("top_cities_to_visit", comment: "")
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -50,14 +50,13 @@ final class CitysCollectionView: UIView {
     private lazy var citysCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.minimumInteritemSpacing = 10
-        layout.minimumLineSpacing = 10
-        let totalHorizontalPadding: CGFloat = 40
+        layout.minimumInteritemSpacing = LayoutConstants.itemSpacing
+        layout.minimumLineSpacing = LayoutConstants.itemSpacing
+        let totalHorizontalPadding: CGFloat = LayoutConstants.totalHorizontalPadding
         let totalSpacing = layout.minimumInteritemSpacing * 1 // Espacio entre dos celdas
         let availableWidth = UIScreen.main.bounds.width - totalHorizontalPadding - layout.minimumInteritemSpacing
         let itemWidth = availableWidth / 2
-        //layout.itemSize = .init(width: cellWidth, height: 130)
-        layout.itemSize = CGSize(width: itemWidth, height: 130)
+        layout.itemSize = CGSize(width: itemWidth, height: LayoutConstants.cityItemHeight)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.showsVerticalScrollIndicator = false
@@ -82,12 +81,12 @@ extension CitysCollectionView {
         
         NSLayoutConstraint.activate([
             discoverArgentinaLabel.topAnchor.constraint(equalTo: topAnchor),
-            discoverArgentinaLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            discoverArgentinaLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstants.edgePadding),
             discoverArgentinaLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
-            citysCollectionView.topAnchor.constraint(equalTo: discoverArgentinaLabel.bottomAnchor, constant: 16),
-            citysCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-            citysCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+
+            citysCollectionView.topAnchor.constraint(equalTo: discoverArgentinaLabel.bottomAnchor, constant: LayoutConstants.largeSpacing),
+            citysCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstants.edgePadding),
+            citysCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutConstants.edgePadding),
             citysCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
             
         ])

--- a/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverBaCollectionView.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverBaCollectionView.swift
@@ -45,7 +45,7 @@ final class DiscoverBaCollectionView: UIView  {
     private lazy var discoverArgentinaLabel: UILabel = {
         let label = UILabel()
         label.textColor = .black
-        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.font = .systemFont(ofSize: LayoutConstants.sectionHeaderFontSize, weight: .semibold)
         label.textAlignment = .left
         label.text = NSLocalizedString("discover_buenos_aires", comment: "")
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -54,9 +54,9 @@ final class DiscoverBaCollectionView: UIView  {
 
     private lazy var discoverCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
-        layout.itemSize = .init(width: 160, height: 120)
+        layout.itemSize = .init(width: LayoutConstants.discoverItemWidth, height: LayoutConstants.discoverItemHeight)
         layout.scrollDirection = .horizontal
-        layout.minimumLineSpacing = 10
+        layout.minimumLineSpacing = LayoutConstants.itemSpacing
 
         let vw = UICollectionView(frame: .zero, collectionViewLayout: layout)
         vw.register(DiscoverCell.self, forCellWithReuseIdentifier: "DiscoverCell")
@@ -109,14 +109,14 @@ private extension DiscoverBaCollectionView  {
         
         NSLayoutConstraint.activate([
             discoverArgentinaLabel.topAnchor.constraint(equalTo: topAnchor),
-            discoverArgentinaLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            discoverArgentinaLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstants.edgePadding),
             discoverArgentinaLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
-            discoverCollectionView.topAnchor.constraint(equalTo: discoverArgentinaLabel.bottomAnchor, constant: 16),
-            discoverCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-            discoverCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+
+            discoverCollectionView.topAnchor.constraint(equalTo: discoverArgentinaLabel.bottomAnchor, constant: LayoutConstants.largeSpacing),
+            discoverCollectionView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstants.edgePadding),
+            discoverCollectionView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutConstants.edgePadding),
             discoverCollectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
-            
+
         ])
     }
 }

--- a/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverCell.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/DiscoverCollectionView/DiscoverCell.swift
@@ -16,15 +16,15 @@ final class DiscoverCell: UICollectionViewCell  {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
-        view.layer.cornerRadius = 6
-        
+        view.layer.cornerRadius = LayoutConstants.discoverCellCornerRadius
+
         return view
     }()
     
     private lazy var titleLabel : UILabel = {
         var label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
+        label.font = UIFont.systemFont(ofSize: LayoutConstants.discoverCellTitleFontSize, weight: .medium)
         label.textColor = UIColor(named: "primaryTextColor") ?? .black
         label.textAlignment = .center
         return label
@@ -58,7 +58,7 @@ private extension DiscoverCell  {
     
     func addsubviews() {
         self.backgroundColor = .white
-        self.layer.cornerRadius = 6
+        self.layer.cornerRadius = LayoutConstants.discoverCellCornerRadius
 
         contentView.addSubview(imageView)
         contentView.addSubview(titleLabel)
@@ -69,10 +69,10 @@ private extension DiscoverCell  {
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            imageView.heightAnchor.constraint(equalToConstant: 90),
-            imageView.widthAnchor.constraint(equalToConstant: 160),
+            imageView.heightAnchor.constraint(equalToConstant: LayoutConstants.discoverImageHeight),
+            imageView.widthAnchor.constraint(equalToConstant: LayoutConstants.discoverItemWidth),
 
-            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 8),
+            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: LayoutConstants.smallPadding),
             titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])

--- a/Pesoblu/Modules/Home/View/SubViews/QuickConversorView/QuickConversorView.swift
+++ b/Pesoblu/Modules/Home/View/SubViews/QuickConversorView/QuickConversorView.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 final class QuickConversorView: UIView{
-    
+
     private lazy var titleLabel : UILabel = {
         var label = UILabel()
         label.text = NSLocalizedString("quick_converter_title", comment: "")
-        label.font = UIFont.boldSystemFont(ofSize: 22)
+        label.font = UIFont.boldSystemFont(ofSize: LayoutConstants.converterTitleFontSize)
         label.textColor = UIColor(named: "primaryText") ?? UIColor.black
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -21,7 +21,7 @@ final class QuickConversorView: UIView{
     private lazy var usdContainerView : UIView = {
         var view = UIView()
         view.backgroundColor = .white
-        view.layer.cornerRadius = 8
+        view.layer.cornerRadius = LayoutConstants.containerCornerRadius
         view.layer.borderColor = UIColor.lightGray.cgColor
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
@@ -30,7 +30,7 @@ final class QuickConversorView: UIView{
     private lazy var usdCodeLabel : UILabel = {
         var codeLabel = UILabel()
         codeLabel.text = NSLocalizedString("usd_code", comment: "")
-        codeLabel.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        codeLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyCodeFontSize, weight: .medium)
         codeLabel.textColor = UIColor(named: "primaryText") ?? UIColor.black
         codeLabel.translatesAutoresizingMaskIntoConstraints = false
         return codeLabel
@@ -39,7 +39,7 @@ final class QuickConversorView: UIView{
     private lazy var usdDescriptionLabel : UILabel = {
         var descriptionLabel = UILabel()
         descriptionLabel.text = NSLocalizedString("usd_description", comment: "")
-        descriptionLabel.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        descriptionLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyDescriptionFontSize, weight: .regular)
         descriptionLabel.textColor = UIColor(named: "secondaryText") ?? UIColor.gray
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         return descriptionLabel
@@ -48,7 +48,7 @@ final class QuickConversorView: UIView{
     private lazy var usdValueLabel : UILabel = {
         var valueLabel = UILabel()
         valueLabel.text = NSLocalizedString("default_usd_value", comment: "")
-        valueLabel.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        valueLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyValueFontSize, weight: .regular)
         valueLabel.textColor = UIColor(named: "primaryText") ?? UIColor.black
         valueLabel.textAlignment = .right
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -57,9 +57,9 @@ final class QuickConversorView: UIView{
     
     private lazy var usdLabelsStackView : UIStackView = {
         var labelStackView =  UIStackView(arrangedSubviews: [usdCodeLabel, usdDescriptionLabel])
-        
+
         labelStackView.axis = .vertical
-        labelStackView.spacing = 4
+        labelStackView.spacing = LayoutConstants.tinySpacing
         labelStackView.translatesAutoresizingMaskIntoConstraints = false
         return labelStackView
     }()
@@ -67,7 +67,7 @@ final class QuickConversorView: UIView{
     private lazy var arsContainerView : UIView = {
         var view = UIView()
         view.backgroundColor = .white
-        view.layer.cornerRadius = 8
+        view.layer.cornerRadius = LayoutConstants.containerCornerRadius
         view.layer.borderColor = UIColor.lightGray.cgColor
         view.translatesAutoresizingMaskIntoConstraints = false
         
@@ -77,7 +77,7 @@ final class QuickConversorView: UIView{
     private lazy var arsCodeLabel : UILabel = {
         var codeLabel = UILabel()
         codeLabel.text = NSLocalizedString("ars_code", comment: "")
-        codeLabel.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        codeLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyCodeFontSize, weight: .medium)
         codeLabel.textColor = UIColor(named: "primaryText") ?? UIColor.black
         codeLabel.translatesAutoresizingMaskIntoConstraints = false
         return codeLabel
@@ -86,7 +86,7 @@ final class QuickConversorView: UIView{
     private lazy var arsDescriptionLabel : UILabel = {
         var descriptionLabel = UILabel()
         descriptionLabel.text = NSLocalizedString("ars_description", comment: "")
-        descriptionLabel.font = UIFont.systemFont(ofSize: 14, weight: .regular)
+        descriptionLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyDescriptionFontSize, weight: .regular)
         descriptionLabel.textColor = UIColor(named: "secondaryText") ?? UIColor.gray
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         return descriptionLabel
@@ -95,7 +95,7 @@ final class QuickConversorView: UIView{
     private lazy var arsValueLabel : UILabel = {
         var valueLabel = UILabel()
         valueLabel.text = NSLocalizedString("default_ars_value", comment: "")
-        valueLabel.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        valueLabel.font = UIFont.systemFont(ofSize: LayoutConstants.currencyValueFontSize, weight: .regular)
         valueLabel.textColor = UIColor(named: "primaryText") ?? UIColor.black
         valueLabel.textAlignment = .right
         valueLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -104,18 +104,18 @@ final class QuickConversorView: UIView{
     
     private lazy var arsLabelsStackView : UIStackView = {
         var labelStackView =  UIStackView(arrangedSubviews: [arsCodeLabel, arsDescriptionLabel])
-        
+
         labelStackView.axis = .vertical
-        labelStackView.spacing = 4
+        labelStackView.spacing = LayoutConstants.tinySpacing
         labelStackView.translatesAutoresizingMaskIntoConstraints = false
         return labelStackView
     }()
     
     private lazy var stackView: UIStackView = {
         var stackview = UIStackView(arrangedSubviews: [usdContainerView, arsContainerView])
-        
+
         stackview.axis = .vertical
-        stackview.spacing = 8
+        stackview.spacing = LayoutConstants.smallPadding
         stackview.translatesAutoresizingMaskIntoConstraints = false
         return stackview
     }()
@@ -161,33 +161,33 @@ extension QuickConversorView{
     func setupConstraints(){
         NSLayoutConstraint.activate([
             // Title Label Constraints
-            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10),
-            titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10),
-            titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 8),
+            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: LayoutConstants.edgePadding),
+            titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -LayoutConstants.edgePadding),
+            titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: LayoutConstants.smallPadding),
             
             // Stack View Constraints
-            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10),
-            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -10),
-            stackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: LayoutConstants.edgePadding),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -LayoutConstants.edgePadding),
+            stackView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: LayoutConstants.smallPadding),
             
-            usdContainerView.heightAnchor.constraint(equalToConstant: 50),
-            arsContainerView.heightAnchor.constraint(equalToConstant: 50),
+            usdContainerView.heightAnchor.constraint(equalToConstant: LayoutConstants.converterContainerHeight),
+            arsContainerView.heightAnchor.constraint(equalToConstant: LayoutConstants.converterContainerHeight),
             
-            usdLabelsStackView.leadingAnchor.constraint(equalTo: usdContainerView.leadingAnchor, constant: 8),
+            usdLabelsStackView.leadingAnchor.constraint(equalTo: usdContainerView.leadingAnchor, constant: LayoutConstants.smallPadding),
             usdLabelsStackView.centerYAnchor.constraint(equalTo: usdContainerView.centerYAnchor),
             
-            usdValueLabel.trailingAnchor.constraint(equalTo: usdContainerView.trailingAnchor, constant: -16),
+            usdValueLabel.trailingAnchor.constraint(equalTo: usdContainerView.trailingAnchor, constant: -LayoutConstants.largeSpacing),
             usdValueLabel.centerYAnchor.constraint(equalTo: usdContainerView.centerYAnchor),
             
-            usdValueLabel.widthAnchor.constraint(equalToConstant: 80),
+            usdValueLabel.widthAnchor.constraint(equalToConstant: LayoutConstants.valueLabelWidth),
             
-            arsLabelsStackView.leadingAnchor.constraint(equalTo: arsContainerView.leadingAnchor, constant: 8),
+            arsLabelsStackView.leadingAnchor.constraint(equalTo: arsContainerView.leadingAnchor, constant: LayoutConstants.smallPadding),
             arsLabelsStackView.centerYAnchor.constraint(equalTo: arsContainerView.centerYAnchor),
             
-            arsValueLabel.trailingAnchor.constraint(equalTo: arsContainerView.trailingAnchor, constant: -16),
+            arsValueLabel.trailingAnchor.constraint(equalTo: arsContainerView.trailingAnchor, constant: -LayoutConstants.largeSpacing),
             arsValueLabel.centerYAnchor.constraint(equalTo: arsContainerView.centerYAnchor),
             
-            arsValueLabel.widthAnchor.constraint(equalToConstant: 80)
+            arsValueLabel.widthAnchor.constraint(equalToConstant: LayoutConstants.valueLabelWidth)
         ])
         
     }

--- a/Pesoblu/Utils/LayoutConstants.swift
+++ b/Pesoblu/Utils/LayoutConstants.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// Centralized layout metrics for consistent spacing and sizing across the app.
+enum LayoutConstants {
+    // MARK: - Padding and Spacing
+    /// Default horizontal padding for leading and trailing anchors.
+    static let edgePadding: CGFloat = 10
+    /// Small padding used for top/bottom spacing and compact insets.
+    static let smallPadding: CGFloat = 8
+    /// Large spacing used to separate sections vertically.
+    static let largeSpacing: CGFloat = 16
+    /// Spacing between items in collection views.
+    static let itemSpacing: CGFloat = 10
+    /// Tiny spacing for closely related elements such as stacked labels.
+    static let tinySpacing: CGFloat = 4
+    /// Extra small padding used inside cells for tight layouts.
+    static let extraSmallPadding: CGFloat = 5
+
+    // MARK: - Sizes
+    /// Standard height for currency containers in the quick converter.
+    static let converterContainerHeight: CGFloat = 50
+    /// Width for value labels in the quick converter.
+    static let valueLabelWidth: CGFloat = 80
+    /// Height for images displayed in city cells.
+    static let cityImageHeight: CGFloat = 100
+    /// Height for city items in the collection view.
+    static let cityItemHeight: CGFloat = 130
+    /// Width for items in the discover collection view and images inside discover cells.
+    static let discoverItemWidth: CGFloat = 160
+    /// Height for items in the discover collection view.
+    static let discoverItemHeight: CGFloat = 120
+    /// Height for images inside discover cells.
+    static let discoverImageHeight: CGFloat = 90
+
+    // MARK: - Corner Radius
+    /// Corner radius applied to rounded container views.
+    static let containerCornerRadius: CGFloat = 8
+    /// Corner radius for city collection view cells.
+    static let cityCellCornerRadius: CGFloat = 10
+    /// Corner radius for discover cells and their images.
+    static let discoverCellCornerRadius: CGFloat = 6
+
+    // MARK: - Fonts
+    /// Title font size for the quick converter.
+    static let converterTitleFontSize: CGFloat = 22
+    /// Font size for currency code labels.
+    static let currencyCodeFontSize: CGFloat = 16
+    /// Font size for currency description labels.
+    static let currencyDescriptionFontSize: CGFloat = 14
+    /// Font size for currency value labels.
+    static let currencyValueFontSize: CGFloat = 16
+    /// Font size for section headers such as "Discover Buenos Aires".
+    static let sectionHeaderFontSize: CGFloat = 18
+    /// Font size for titles in city cells.
+    static let cityCellTitleFontSize: CGFloat = 16
+    /// Font size for titles in discover cells.
+    static let discoverCellTitleFontSize: CGFloat = 18
+
+    // MARK: - Layout Calculations
+    /// Total horizontal padding considered when computing available width for city collection view items.
+    static let totalHorizontalPadding: CGFloat = 40
+}
+


### PR DESCRIPTION
## Summary
- add `LayoutConstants` enum to centralize spacing, sizing and font metrics
- replace hardcoded numbers in home subviews with reusable constants

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project Pesoblu.xcodeproj -scheme Pesoblu -sdk iphonesimulator test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68966b6982ac8333a4b59f2a9f6d6104