### PR TITLE
Use loadViewIfNeeded and pre-load hooks in PlaceViewController tests

### DIFF
--- a/PesobluTests/ViewControllers/PlaceViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/PlaceViewControllerTests.swift
@@ -95,7 +95,7 @@ final class PlaceViewControllerTests: XCTestCase {
             }
             
         }
-        _ = sut.view
+        sut.loadViewIfNeeded()
         // When
         sut.toggleFavorite()
         
@@ -106,14 +106,13 @@ final class PlaceViewControllerTests: XCTestCase {
     
     func test_loadFavoriteStatus_setsIsFavoriteTrue() {
         mockViewModel.favoriteResult = true
-        _ = sut.view
         let exp = expectation(description: "isFavorite actualizado a true")
 
         sut.onFavoriteUpdated = { isFav in
             if isFav { exp.fulfill() }
         }
 
-        sut.loadFavoriteStatus()
+        sut.loadViewIfNeeded()
 
         wait(for: [exp], timeout: 1.0)
         XCTAssertTrue(sut.test_isFavorite)


### PR DESCRIPTION
## Summary
- Load PlaceViewController's view with `loadViewIfNeeded()` in unit tests
- Set `onFavoriteUpdated` before invoking `loadFavoriteStatus` to avoid missing initial callback

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme Pesoblu -project Pesoblu.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a8bae7cf0833390b1b4c246425b16