### PR TITLE
Add accessibility identifiers for labels and cells

### DIFF
--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCell.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCell.swift
@@ -15,6 +15,7 @@ final class FilterCell: UICollectionViewCell {
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
         view.layer.cornerRadius = 8
+        view.isAccessibilityElement = false
         return view
     }()
     
@@ -24,17 +25,21 @@ final class FilterCell: UICollectionViewCell {
         label.font = UIFont.systemFont(ofSize: 16, weight: .bold)
         label.textColor = UIColor(named: "primaryTextColor") ?? .black
         label.textAlignment = .center
+        label.isAccessibilityElement = false
         return label
     }()
-    
+
     func set(image: String, title: String) {
         imageView.image = UIImage(named: image)
         titleLabel.text = title
+        accessibilityLabel = title
+        accessibilityIdentifier = "filterCell_\(title.replacingOccurrences(of: " ", with: "_"))"
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        isAccessibilityElement = true
     }
     
     /// This view is intended to be instantiated programmatically.

--- a/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/FilterCollectionView/FilterCollectionView.swift
@@ -43,9 +43,10 @@ final class FilterCollectionView: UIView {
         label.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
         label.text = "Filtros"
         label.textAlignment = .center
-        
         label.translatesAutoresizingMaskIntoConstraints = false
-        
+        label.isAccessibilityElement = true
+        label.accessibilityLabel = label.text
+        label.accessibilityIdentifier = "filter_label"
         return label
     }()
     

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlaceCell.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlaceCell.swift
@@ -22,6 +22,7 @@ final class PlaceCell: UICollectionViewCell  {
         image.layer.cornerRadius = 4
         image.clipsToBounds = true
         image.translatesAutoresizingMaskIntoConstraints = false
+        image.isAccessibilityElement = false
         return image
     }()
     
@@ -30,6 +31,7 @@ final class PlaceCell: UICollectionViewCell  {
         label.font = .systemFont(ofSize: 14, weight: .medium)
         label.textColor = .label
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.isAccessibilityElement = false
         return label
     }()
     
@@ -38,6 +40,7 @@ final class PlaceCell: UICollectionViewCell  {
         label.font = .systemFont(ofSize: 12, weight: .regular)
         label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.isAccessibilityElement = false
         return label
     }()
     
@@ -46,6 +49,7 @@ final class PlaceCell: UICollectionViewCell  {
         label.font = .systemFont(ofSize: 12, weight: .regular)
         label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.isAccessibilityElement = false
         return label
     }()
     
@@ -54,6 +58,7 @@ final class PlaceCell: UICollectionViewCell  {
         label.font = .systemFont(ofSize: 12, weight: .regular)
         label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.isAccessibilityElement = false
         return label
     }()
     
@@ -66,6 +71,8 @@ final class PlaceCell: UICollectionViewCell  {
         priceLabel.text = price
         typeLabel.text = type
         distanceLabel.text = formattedDistance
+        accessibilityLabel = "\(title), \(type), \(price), \(formattedDistance)"
+        accessibilityIdentifier = "placeCell_\(title.replacingOccurrences(of: " ", with: "_"))"
     }
     
     func updateImage(url: String) {
@@ -91,6 +98,7 @@ final class PlaceCell: UICollectionViewCell  {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        isAccessibilityElement = true
     }
     
     /// This view is intended to be instantiated programmatically.

--- a/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
+++ b/Pesoblu/Modules/PlacesList/View/SubViews/PlacesListCollectionView/PlacesListCollectionView.swift
@@ -33,7 +33,9 @@ final class PlacesListCollectionView: UIView  {
 
     func updateData(with items: [PlaceItemViewModel]) {
         placeData = items
-        quantityLabel.text = "\(placeData.count) lugares"
+        let text = "\(placeData.count) lugares"
+        quantityLabel.text = text
+        quantityLabel.accessibilityLabel = text
         delegate?.didUpdateItemCount(placeData.count)
         placeCollectionView.reloadData()
     }
@@ -45,7 +47,9 @@ final class PlacesListCollectionView: UIView  {
         label.text = "Cantidad de restaurantes"
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
-        
+        label.isAccessibilityElement = true
+        label.accessibilityIdentifier = "quantity_label"
+        label.accessibilityLabel = label.text
         return label
     }()
     


### PR DESCRIPTION
## Summary
- tag filter section label with accessibility identifier and label
- expose quantity label updates to accessibility
- ensure filter and place cells are accessibility elements with identifiers

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689aa97add148333ae1223173517db16