### PR TITLE
Add AlertPresentable protocol for Home alerts

### DIFF
--- a/Pesoblu/Misc/AlertPresenter.swift
+++ b/Pesoblu/Misc/AlertPresenter.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+protocol AlertPresentable {
+    func show(message: String, on viewController: UIViewController)
+}
+
+struct AlertPresenter: AlertPresentable {
+    func show(message: String, on viewController: UIViewController) {
+        let alert = UIAlertController(title: NSLocalizedString("error_title", comment: ""),
+                                      message: message,
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("ok_action", comment: ""),
+                                      style: .default))
+        viewController.present(alert, animated: true)
+    }
+}
+

--- a/Pesoblu/Modules/Home/View/HomeViewController.swift
+++ b/Pesoblu/Modules/Home/View/HomeViewController.swift
@@ -12,23 +12,25 @@ final class HomeViewController: UIViewController  {
     internal private(set) var quickConversorView : QuickConversorView
     internal private(set) var discoverBaCView : DiscoverBaCollectionView
     internal private(set) var citiesCView : CitiesCollectionView
-    internal private(set) var alertMessage: String?
     private var onSelect : (([PlaceItem], String, PlaceType) -> Void)?
     
     private var collectionViewHeightConstraint: NSLayoutConstraint!
     
     private let homeViewModel: HomeViewModelProtocol
+    private let alertPresenter: AlertPresentable
     
     init(homeViewModel: HomeViewModelProtocol,
          quickConversorView: QuickConversorView = QuickConversorView(),
          discoverBaCView: DiscoverBaCollectionView? = nil,
-         citiesCView: CitiesCollectionView? = nil) {
-        
+         citiesCView: CitiesCollectionView? = nil,
+         alertPresenter: AlertPresentable = AlertPresenter()) {
+
         self.homeViewModel = homeViewModel
         self.quickConversorView = quickConversorView
         self.discoverBaCView = discoverBaCView ?? DiscoverBaCollectionView(homeViewModel: homeViewModel)
         self.citiesCView = citiesCView ?? CitiesCollectionView(homeViewModel: homeViewModel)
-        
+        self.alertPresenter = alertPresenter
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -244,10 +246,7 @@ extension HomeViewController: CollectionViewSelectionDelegate {
     }
 
     func showAlert(message: String) {
-        self.alertMessage = message
-        let alert = UIAlertController(title: NSLocalizedString("error_title", comment: ""), message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("ok_action", comment: ""), style: .default))
-        present(alert, animated: true, completion: nil)
+        alertPresenter.show(message: message, on: self)
     }
 }
 

--- a/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
+++ b/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
@@ -9,11 +9,11 @@ import UIKit
 import MapKit
 import CoreData
 
-protocol AlertPresenter  {
+protocol AlertPresenterProtocol  {
     func present(on viewController: UIViewController, title: String, message: String)
 }
 
-struct DefaultAlertPresenter: AlertPresenter  {
+struct DefaultAlertPresenter: AlertPresenterProtocol  {
     func present(on viewController: UIViewController, title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
@@ -26,7 +26,7 @@ final class PlaceViewController: UIViewController  {
     private lazy var placeView = PlaceView()
     private let placeViewModel: PlaceViewModelProtocol
     private let place: PlaceItem
-    private let alertPresenter: AlertPresenter
+    private let alertPresenter: AlertPresenterProtocol
     
 #if DEBUG
     var test_isFavorite: Bool { isFavorite }
@@ -44,7 +44,7 @@ final class PlaceViewController: UIViewController  {
     
     init(placeViewModel: PlaceViewModelProtocol,
          place: PlaceItem,
-         alertPresenter: AlertPresenter = DefaultAlertPresenter()) {
+         alertPresenter: AlertPresenterProtocol = DefaultAlertPresenter()) {
 
         self.placeViewModel = placeViewModel
         self.place = place

--- a/PesobluTests/ViewControllers/HomeViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/HomeViewControllerTests.swift
@@ -16,13 +16,18 @@ final class HomeViewControllerTests: XCTestCase {
     private var citiesCView: CitiesCollectionView!
     private var discoverBaCView: DiscoverBaCollectionView!
     private var quickConversorView: QuickConversorView!
+    private var mockAlertPresenter: MockAlertPresenter!
     
     override func setUp() {
         super.setUp()
         citiesCView = CitiesCollectionView(homeViewModel: mockViewModel)
         discoverBaCView = DiscoverBaCollectionView(homeViewModel: mockViewModel)
         quickConversorView = QuickConversorView()
-        sut = HomeViewController(homeViewModel: mockViewModel, quickConversorView: quickConversorView, discoverBaCView: discoverBaCView)
+        mockAlertPresenter = MockAlertPresenter()
+        sut = HomeViewController(homeViewModel: mockViewModel,
+                                 quickConversorView: quickConversorView,
+                                 discoverBaCView: discoverBaCView,
+                                 alertPresenter: mockAlertPresenter)
         _ = sut.view // Carga la vista
     }
     
@@ -31,6 +36,7 @@ final class HomeViewControllerTests: XCTestCase {
         citiesCView = nil
         discoverBaCView = nil
         quickConversorView = nil
+        mockAlertPresenter = nil
         super.tearDown()
     }
     
@@ -74,7 +80,7 @@ final class HomeViewControllerTests: XCTestCase {
         
         mockViewModel.onGetDolarBlueCalled = {
             DispatchQueue.main.async {
-                XCTAssertEqual(self.sut.alertMessageForTesting, NSLocalizedString("invalid_url_error", comment: ""))
+                XCTAssertEqual(self.mockAlertPresenter.lastMessage, NSLocalizedString("invalid_url_error", comment: ""))
                 expectation.fulfill()
             }
         }
@@ -93,6 +99,14 @@ final class HomeViewControllerTests: XCTestCase {
     func testDiscoverCollectionView_LoadDataLoadsItems() {
         sut.discoverBaCViewForTesting.loadData()
         XCTAssertEqual(sut.discoverBaCViewForTesting.collectionViewForTesting.numberOfItems(inSection: 0), 2) // 2 ítems ficticios
+    }
+}
+
+final class MockAlertPresenter: AlertPresentable {
+    var lastMessage: String?
+
+    func show(message: String, on viewController: UIViewController) {
+        lastMessage = message
     }
 }
 

--- a/PesobluTests/ViewControllers/PlaceViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/PlaceViewControllerTests.swift
@@ -31,7 +31,7 @@ final class PlaceViewControllerTests: XCTestCase {
     }
 
 
-    final class MockAlertPresenter: AlertPresenter {
+    final class MockAlertPresenter: AlertPresenterProtocol {
         var didShowAlert = false
         var alertTitle: String?
         var alertMessage: String?


### PR DESCRIPTION
## Summary
- Add `AlertPresentable` protocol with `AlertPresenter` default implementation
- Inject `alertPresenter` into `HomeViewController` and route alerts through it
- Rename existing `AlertPresenter` protocol to `AlertPresenterProtocol` for Place module and update tests to use mocks

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689bccb15c388333bb8e9a5f290c5c3a