### PR TITLE
Fix quick conversor invalid URL test

### DIFF
--- a/PesobluTests/ViewControllers/HomeViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/HomeViewControllerTests.swift
@@ -86,15 +86,20 @@ final class HomeViewControllerTests: XCTestCase {
         mockViewModel.shouldFail = true
         mockViewModel.apiError = .invalidURL
         let expectation = expectation(description: "Invalid URL shows alert")
-        
-        mockViewModel.onGetDolarBlueCalled = {
+        expectation.assertForOverFulfill = true
+
+        mockViewModel.onGetDolarBlueCalled = { [weak self] in
             DispatchQueue.main.async {
+                guard let self else { return }
+                XCTAssertTrue(Thread.isMainThread)
                 XCTAssertEqual(self.mockAlertPresenter.lastMessage, NSLocalizedString("invalid_url_error", comment: ""))
                 expectation.fulfill()
             }
         }
-        let pExp = expectation(for: predicate, evaluatedWith: nil)
-        wait(for: [pExp], timeout: 2.0) // subí el timeout si tu máquina está cargada
+
+        sut.setupQuickConversor()
+
+        wait(for: [expectation], timeout: 2.0)
     }
     
     @MainActor


### PR DESCRIPTION
## Summary
- Replace outdated predicate expectation with direct wait in invalid URL test
- Invoke `setupQuickConversor` after configuring failure closure
- Ensure assertions run on the main thread and prevent multiple fulfills

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Pesoblu.xcodeproj -scheme Pesoblu -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_689be616c0788333b5c5a773986f7767