### PR TITLE
Refactor invalid URL test to use delayed alert assertion

### DIFF
--- a/PesobluTests/ViewControllers/HomeViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/HomeViewControllerTests.swift
@@ -88,16 +88,12 @@ final class HomeViewControllerTests: XCTestCase {
         let expectation = expectation(description: "Invalid URL shows alert")
         expectation.assertForOverFulfill = true
 
-        mockViewModel.onGetDolarBlueCalled = { [weak self] in
-            DispatchQueue.main.async {
-                guard let self else { return }
-                XCTAssertTrue(Thread.isMainThread)
-                XCTAssertEqual(self.mockAlertPresenter.lastMessage, NSLocalizedString("invalid_url_error", comment: ""))
-                expectation.fulfill()
-            }
-        }
-
         sut.setupQuickConversor()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(self.mockAlertPresenter.lastMessage, NSLocalizedString("invalid_url_error", comment: ""))
+            expectation.fulfill()
+        }
 
         wait(for: [expectation], timeout: 2.0)
     }


### PR DESCRIPTION
## Summary
- simplify invalid URL quick conversor test by removing callback dependency
- check alert message with a delayed main-thread assertion

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bea6ce40c83339bdc3826d818b171