### PR TITLE
Rename addSubviews in ChangeView and clarify private names

### DIFF
--- a/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
@@ -89,7 +89,7 @@ class ChangeView: UIView  {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setup()
+        configureView()
     }
     
     /// This view is intended to be instantiated programmatically.
@@ -115,13 +115,13 @@ class ChangeView: UIView  {
 }
 
 private extension ChangeView  {
-    func setup() {
-        
-        addsubviews()
+    func configureView() {
+
+        addSubviews()
         setupConstraints()
     }
-    
-    private func addsubviews() {
+
+    private func addSubviews() {
         self.backgroundColor = .clear
         self.layer.cornerRadius = 10
         self.addSubview(viewDolar)


### PR DESCRIPTION
## Summary
- rename `addsubviews` to `addSubviews` for proper Swift casing
- replace `setup()` with `configureView()` for clearer intent

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Pesoblu.xcodeproj -scheme Pesoblu` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf81f646883339e83275f4d20f4c0