### PR TITLE
Reset ChangeCell content on reuse

### DIFF
--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
@@ -20,7 +20,12 @@ class ChangeCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         return nil
     }
-    
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        changeView.set(currencyTitle: "", currencyLabel: "", valueBuy: "")
+    }
+
     func set(currencyTitle: String, currencyLabel: String, valueBuy: String) {
         changeView.set(currencyTitle: currencyTitle,
                        currencyLabel: currencyLabel,

--- a/PesobluTests/Views/Change/ChangeCellTests.swift
+++ b/PesobluTests/Views/Change/ChangeCellTests.swift
@@ -1,0 +1,39 @@
+//
+//  ChangeCellTests.swift
+//  PesobluTests
+//
+//  Created by OpenAI's ChatGPT on 2025.
+//
+
+import XCTest
+import UIKit
+@testable import Pesoblu
+
+final class ChangeCellTests: XCTestCase {
+
+    private func allLabels(in view: UIView) -> [UILabel] {
+        var result: [UILabel] = []
+        for subview in view.subviews {
+            if let label = subview as? UILabel {
+                result.append(label)
+            } else {
+                result.append(contentsOf: allLabels(in: subview))
+            }
+        }
+        return result
+    }
+
+    func testPrepareForReuseClearsContent() {
+        let cell = ChangeCell()
+        cell.set(currencyTitle: "USD", currencyLabel: "Dollar", valueBuy: "100")
+
+        let labelsBefore = allLabels(in: cell.contentView)
+        XCTAssertFalse(labelsBefore.allSatisfy { ($0.text ?? "").isEmpty })
+
+        cell.prepareForReuse()
+
+        let labelsAfter = allLabels(in: cell.contentView)
+        XCTAssertTrue(labelsAfter.allSatisfy { ($0.text ?? "").isEmpty })
+    }
+}
+


### PR DESCRIPTION
## Summary
- Clear ChangeCell's labels when reused to avoid showing stale data
- Add unit test for ChangeCell reset logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689cfdf0cbfc8333b6768873cf03b97d