### PR TITLE
Use safe dequeuing for ChangeCell

### DIFF
--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCell.swift
@@ -7,7 +7,9 @@
 import UIKit
 
 class ChangeCell: UICollectionViewCell {
-    
+
+    static let identifier = "ChangeCell"
+
     private lazy var changeView = ChangeView()
     
     override init(frame: CGRect) {

--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
@@ -45,7 +45,7 @@ extension ChangeCollectionView {
 private extension ChangeCollectionView {
     func setup() {
         
-        collectionView.register(ChangeCell.self, forCellWithReuseIdentifier: "ChangeCell")
+        collectionView.register(ChangeCell.self, forCellWithReuseIdentifier: ChangeCell.identifier)
         collectionView.backgroundColor = .clear
         collectionView.isScrollEnabled = false
         collectionView.dataSource = self
@@ -91,13 +91,18 @@ extension ChangeCollectionView: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let item = viewModel.currencies[indexPath.item]
-        
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ChangeCell", for: indexPath) as! ChangeCell
-        
+
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ChangeCell.identifier,
+            for: indexPath
+        ) as? ChangeCell else {
+            fatalError("Could not dequeue ChangeCell")
+        }
+
         cell.set(currencyTitle: item.currencyTitle ?? "",
                  currencyLabel: item.currencyLabel ?? "",
                  valueBuy: item.rate ?? "")
-        
+
         return cell
     }
 }

--- a/PesobluTests/Views/Change/ChangeCellTests.swift
+++ b/PesobluTests/Views/Change/ChangeCellTests.swift
@@ -35,5 +35,18 @@ final class ChangeCellTests: XCTestCase {
         let labelsAfter = allLabels(in: cell.contentView)
         XCTAssertTrue(labelsAfter.allSatisfy { ($0.text ?? "").isEmpty })
     }
+
+    func testDequeuesChangeCellWithIdentifier() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.register(ChangeCell.self, forCellWithReuseIdentifier: ChangeCell.identifier)
+
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: ChangeCell.identifier,
+            for: IndexPath(item: 0, section: 0)
+        )
+
+        XCTAssertTrue(cell is ChangeCell)
+    }
 }
 


### PR DESCRIPTION
## Summary
- add static identifier on `ChangeCell`
- use guard to safely dequeue `ChangeCell` and avoid force casting
- add unit test ensuring `ChangeCell` dequeues with identifier

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d00a197448333bcc6a547de95b048