### PR TITLE
Use collection view content size for dynamic height

### DIFF
--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
@@ -70,8 +70,9 @@ private extension ChangeCollectionView {
 extension ChangeCollectionView: ChangeViewModelDelegate {
     func didFinish() {
         collectionView.reloadData()
-        DispatchQueue.main.async{
-            let totalHeight = CGFloat(self.viewModel.currencies.count) * 90
+        DispatchQueue.main.async {
+            self.collectionView.layoutIfNeeded()
+            let totalHeight = self.collectionView.collectionViewLayout.collectionViewContentSize.height
             self.onHeightChange?(totalHeight)
         }
     }

--- a/PesobluTests/Views/Change/ChangeCollectionViewTests.swift
+++ b/PesobluTests/Views/Change/ChangeCollectionViewTests.swift
@@ -1,0 +1,58 @@
+//
+//  ChangeCollectionViewTests.swift
+//  PesobluTests
+//
+//  Created by OpenAI's ChatGPT on 2025.
+//
+
+import XCTest
+import UIKit
+@testable import Pesoblu
+
+final class ChangeCollectionViewTests: XCTestCase {
+
+    private final class MockViewModel: ChangeViewModelProtocol {
+        var delegate: ChangeViewModelDelegate?
+        var currencies: [CurrencyItem]
+
+        init(currencies: [CurrencyItem] = []) {
+            self.currencies = currencies
+        }
+
+        func getChangeOfCurrencies() {
+            delegate?.didFinish()
+        }
+
+        func sendDidFinish() {
+            delegate?.didFinish()
+        }
+    }
+
+    private func makeCurrencies(count: Int) -> [CurrencyItem] {
+        return (0..<count).map { _ in
+            CurrencyConversion(currencyTitle: nil, currencyLabel: nil, rate: "0")
+        }
+    }
+
+    func testOnHeightChangeMatchesContentHeightForVariousCounts() {
+        let counts = [0, 1, 3]
+        for count in counts {
+            let viewModel = MockViewModel(currencies: makeCurrencies(count: count))
+            let sut = ChangeCollectionView(viewModel: viewModel)
+            let expectation = expectation(description: "height for count \(count)")
+
+            sut.onHeightChange = { height in
+                guard let collectionView = sut.subviews.compactMap({ $0 as? UICollectionView }).first else {
+                    XCTFail("Missing collection view")
+                    return
+                }
+                let expectedHeight = collectionView.collectionViewLayout.collectionViewContentSize.height
+                XCTAssertEqual(height, expectedHeight)
+                expectation.fulfill()
+            }
+
+            viewModel.sendDidFinish()
+            wait(for: [expectation], timeout: 1.0)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- compute collection view height using `collectionViewContentSize.height`
- report dynamic height via `onHeightChange`
- test dynamic height callback across varying item counts

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d03b5cfec83338cb57517fc3497e6