### PR TITLE
Remove print statements and add debug logger

### DIFF
--- a/Pesoblu/App/AppDelegate.swift
+++ b/Pesoblu/App/AppDelegate.swift
@@ -83,18 +83,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationWillEnterForeground(_ application: UIApplication) {
-        print("Voy a pedir los settigs")
+        AppLogger.debug("Voy a pedir los settigs")
         UNUserNotificationCenter.current().getNotificationSettings(completionHandler:
                                                                     {(settings: UNNotificationSettings) in
             if (settings.alertSetting == UNNotificationSetting.enabled) {
-                print("Alert enabled")
+                AppLogger.debug("Alert enabled")
             } else {
-                print("Alert not enabled")
+                AppLogger.debug("Alert not enabled")
             }
             if (settings.badgeSetting == UNNotificationSetting.enabled) {
-                print("Badge enabled")
+                AppLogger.debug("Badge enabled")
             } else {
-                print("Badge not enabled")
+                AppLogger.debug("Badge not enabled")
             }})
     }
 

--- a/Pesoblu/Modules/Change/Model/ChangeResponse.swift
+++ b/Pesoblu/Modules/Change/Model/ChangeResponse.swift
@@ -30,7 +30,6 @@ struct ChangesResponse: Decodable{
             var primerComponente = timeComponents.first
             _ = primerComponente!.removeFirst()
             let prim = primerComponente
-            //print(primerComponente!)
             let segundoComponente = timeComponents[1]
             let tercerComponente = timeComponents[2]
             let tercer = tercerComponente.split(separator: ".")

--- a/Pesoblu/Modules/Change/View/ChangeViewController.swift
+++ b/Pesoblu/Modules/Change/View/ChangeViewController.swift
@@ -115,7 +115,7 @@ extension ChangeViewController {
 
 extension ChangeViewController: ChangeCollectionViewDelegate {
     func didSelectCurrency(for currencyItem: CurrencyItem) {
-        print("didSelectCurrency \(currencyItem)")
+        AppLogger.debug("didSelectCurrency \(currencyItem)")
         onSelectCurrency?(currencyItem)
     }
 }

--- a/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeCollectionView.swift
@@ -78,7 +78,7 @@ extension ChangeCollectionView: ChangeViewModelDelegate {
     }
     
     func didFail(error: any Error) {
-        print(error.localizedDescription)
+        AppLogger.error(error.localizedDescription)
     }
 }
 

--- a/Pesoblu/Modules/CurrencyConverter/ViewModel/CurrencyConverterViewModel.swift
+++ b/Pesoblu/Modules/CurrencyConverter/ViewModel/CurrencyConverterViewModel.swift
@@ -65,7 +65,7 @@ final class CurrencyConverterViewModel: CurrencyConverterViewModelProtocol{
                 try await fetchExchangeRates()
                 try await getDolarMEP()
             } catch {
-                print("Error al obtener los datos: \(error.localizedDescription)")
+                AppLogger.error("Error al obtener los datos: \(error.localizedDescription)")
                 // Podés notificar al delegate también si querés:
                 // delegate?.didFail(error: error)
             }
@@ -169,15 +169,14 @@ extension CurrencyConverterViewModel {
 //                    let dolar = self.dolarMep
 //                    let dolarValue = dolar?.venta ?? 0.0
 //                    let currencyValue = Double(self.valueForCurrency(currencyText: self.selectedCurrency.currencyLabel ?? "0.0")) ?? 0.0
-//                    
+//
 //                    let fromDolarCurrency = String(format: "%.2f", amount * currencyValue)
 //                    let currencyFromPeso = String(format: "%.2f", (amount / dolarValue) * currencyValue)
 //                    let currencyToPeso = String(format: "%.2f", (amount / currencyValue) * dolarValue)
 //                    let currencyToDolarValue = String(format: "%.2f", amount / currencyValue)
-//                    
+//
 //                    promise(.success((currencyFromPeso, currencyToPeso, fromDolarCurrency, currencyToDolarValue)))
 //                } catch {
-//                    print("Error en conversión: \(error)")
 //                    promise(.success(("", "", "", ""))) // Valor por defecto en caso de error
 //                }
 //            }

--- a/Pesoblu/Modules/Favorite/ViewModel/FavoriteViewModel.swift
+++ b/Pesoblu/Modules/Favorite/ViewModel/FavoriteViewModel.swift
@@ -52,7 +52,7 @@ class FavoriteViewModel: ObservableObject{
                     place.distance = distanceService.getDistanceForPlace(place)
                 }
             } catch {
-                print("Error al cargar favoritos: \(error)")
+                AppLogger.error("Error al cargar favoritos: \(error)")
             }
         }
     }

--- a/Pesoblu/Modules/Home/View/HomeViewController.swift
+++ b/Pesoblu/Modules/Home/View/HomeViewController.swift
@@ -194,7 +194,7 @@ extension HomeViewController {
                 if let dolarBlue = try await homeViewModel.getDolarBlue() {
                     quickConversorView.setDolar(dolar: dolarBlue.venta)
                 } else {
-                    print(NSLocalizedString("no_dollar_value", comment: ""))
+                    AppLogger.debug(NSLocalizedString("no_dollar_value", comment: ""))
                 }
                 let countryCode = homeViewModel.getUserCountry() ?? NSLocalizedString("default_country_code", comment: "")
                 let value = try await homeViewModel.getValueForCountry(countryCode: countryCode)

--- a/Pesoblu/Modules/Login/View/LoginViewController.swift
+++ b/Pesoblu/Modules/Login/View/LoginViewController.swift
@@ -111,10 +111,10 @@ extension LoginViewController  {
         do {
             try await authVM.singInWithGoogle()
         } catch let error as AuthenticationViewModel.AuthError {
-            print("AuthError: \(error.localizedDescription)")
+            AppLogger.error("AuthError: \(error.localizedDescription)")
             showErrorAlert(error)
         } catch {
-            print("Unexpected error: \(error.localizedDescription)")
+            AppLogger.error("Unexpected error: \(error.localizedDescription)")
             showErrorAlert(AuthenticationViewModel.AuthError.unknown)
         }
     }
@@ -125,7 +125,7 @@ extension LoginViewController  {
         Analytics.logEvent("user_logged_in", parameters: [
             "user_email": "user@example.com"
         ])
-        print("User tapped Apple Sign-In")
+        AppLogger.debug("User tapped Apple Sign-In")
     }
 }
 

--- a/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
+++ b/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
@@ -117,9 +117,9 @@ extension AuthenticationViewModel{
             if existingUser?.uid != appUser.uid {
                 // Guardar solo si es un usuario nuevo o si hay cambios
                 userService.saveUser(appUser)
-                print("AppUser saved to UserDefaults")
+                AppLogger.debug("AppUser saved to UserDefaults")
             } else {
-                print("User already exists in UserDefaults")
+                AppLogger.debug("User already exists in UserDefaults")
             }
             _authenticationState = .authenticated
             onAuthenticationSuccess?()

--- a/Pesoblu/Service/CityDataService.swift
+++ b/Pesoblu/Service/CityDataService.swift
@@ -23,7 +23,7 @@ class CityDataService: DataManager, CityDataServiceProtocol{
                 cityItems.append(CitiesItem(dict: data as! [String: String]))
             }
         case .failure(let error):
-            print("Error loading CitysAr: \(error)")
+            AppLogger.error("Error loading CitysAr: \(error)")
         }
         return cityItems
     }

--- a/Pesoblu/Service/DiscoverDataService.swift
+++ b/Pesoblu/Service/DiscoverDataService.swift
@@ -24,7 +24,7 @@ class DiscoverDataService: DataManager, DiscoverDataServiceProtocol{
                 discoverItems.append(DiscoverItem(dict: data as! [String: String]))
             }
         case .failure(let error):
-            print("Error loading PlacesBa: \(error)")
+            AppLogger.error("Error loading PlacesBa: \(error)")
         }
         return discoverItems
     }

--- a/Pesoblu/Service/FilterDataService.swift
+++ b/Pesoblu/Service/FilterDataService.swift
@@ -23,7 +23,7 @@ class FilterDataService: DataManager, FilterDataServiceProtocol{
                 discoverItems.append(DiscoverItem(dict: data as! [String: String]))
             }
         case .failure(let error):
-            print("Error loading PlacesBa: \(error)")
+            AppLogger.error("Error loading PlacesBa: \(error)")
         }
         return discoverItems
     }

--- a/Pesoblu/Service/NotificationService.swift
+++ b/Pesoblu/Service/NotificationService.swift
@@ -29,9 +29,9 @@ class NotificationService: NotificationServiceProtocol {
         //notificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier])
         notificationCenter.add(request) { error in
             if let error = error{
-                print(error.localizedDescription)
+                AppLogger.error(error.localizedDescription)
             }else{
-                print("se deberia imprimir")
+                AppLogger.debug("se deberia imprimir")
             }
         }
     }
@@ -50,7 +50,7 @@ class NotificationService: NotificationServiceProtocol {
                 return
             case .authorized:
                 self.dispatchNotificaction(dolar: dolar)
-                print("permitido \(dolar)")
+                AppLogger.debug("permitido \(dolar)")
             default:
                 return
             }

--- a/Pesoblu/Service/PlaceService.swift
+++ b/Pesoblu/Service/PlaceService.swift
@@ -22,7 +22,7 @@ class PlaceService: PlaceServiceProtocol{
     func fetchPlaces(city: String) throws -> [PlaceItem] {
         guard let url = bundle.url(forResource: city, withExtension: "json") else {
             
-            print("No se encontró el archivo CABA.json")
+            AppLogger.error("No se encontró el archivo CABA.json")
             throw PlaceError.fileNotFound
             
         }
@@ -40,7 +40,7 @@ class PlaceService: PlaceServiceProtocol{
             places = try decoder.decode([PlaceItem].self, from: data)
             
         } catch {
-            print(error.localizedDescription)
+            AppLogger.error(error.localizedDescription)
             throw PlaceError.failedToParseData
         }
         

--- a/Pesoblu/Service/UserService.swift
+++ b/Pesoblu/Service/UserService.swift
@@ -29,7 +29,7 @@ final class UserService: UserServiceProtocol {
             let data = try encoder.encode(user)
             UserDefaults.standard.set(data, forKey: userDefaultsKey)
         } catch {
-            print("Failed to save user: \(error.localizedDescription)")
+            AppLogger.error("Failed to save user: \(error.localizedDescription)")
         }
     }
     
@@ -41,7 +41,7 @@ final class UserService: UserServiceProtocol {
             let user = try decoder.decode(AppUser.self, from: data)
             return user
         } catch {
-            print("Failed to load user: \(error.localizedDescription)")
+            AppLogger.error("Failed to load user: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Pesoblu/Utils/AppLogger.swift
+++ b/Pesoblu/Utils/AppLogger.swift
@@ -1,0 +1,19 @@
+import Foundation
+import os.log
+
+enum AppLogger {
+    private static let subsystem = Bundle.main.bundleIdentifier ?? "Pesoblu"
+    private static let debugLog = OSLog(subsystem: subsystem, category: "Debug")
+    private static let errorLog = OSLog(subsystem: subsystem, category: "Error")
+
+    static func debug(_ message: String) {
+        #if DEBUG
+        os_log("%{public}@", log: debugLog, type: .debug, message)
+        #endif
+    }
+
+    static func error(_ message: String) {
+        os_log("%{public}@", log: errorLog, type: .error, message)
+    }
+}
+

--- a/PesobluTests/NoPrintStatementsTests.swift
+++ b/PesobluTests/NoPrintStatementsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+import Foundation
+
+final class NoPrintStatementsTests: XCTestCase {
+    func testNoPrintStatementsInSource() throws {
+        let fileManager = FileManager.default
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let projectRoot = testFileURL.deletingLastPathComponent().deletingLastPathComponent()
+        let sourceURL = projectRoot.appendingPathComponent("Pesoblu")
+        let enumerator = fileManager.enumerator(at: sourceURL, includingPropertiesForKeys: nil)!
+        var violations: [String] = []
+        for case let fileURL as URL in enumerator {
+            guard fileURL.pathExtension == "swift" else { continue }
+            let contents = try String(contentsOf: fileURL)
+            if contents.contains("print(") {
+                violations.append(fileURL.path)
+            }
+        }
+        if !violations.isEmpty {
+            XCTFail("Found print statements in: \(violations.joined(separator: ", "))")
+        }
+    }
+}

--- a/PesobluTests/ViewModels/Change/ChangeViewModelTests.swift
+++ b/PesobluTests/ViewModels/Change/ChangeViewModelTests.swift
@@ -86,12 +86,10 @@ final class ChangeViewModelTests: XCTestCase {
 
 extension ChangeViewModelTests: ChangeViewModelDelegate {
     func didFinish() {
-        print("Fetch completed successfully")
         expectation?.fulfill() // Cumplir la expectativa
     }
-    
+
     func didFail(error: Error) {
-        print("Fetch failed with error: \(error)")
         didFailCalled = true // Actualizar la variable
         expectation?.fulfill() // Cumplir la expectativa
     }


### PR DESCRIPTION
## Summary
- Replace print statements across services and view controllers with environment-aware `AppLogger`
- Introduce `AppLogger` using `os_log` for debug and error logging
- Add unit test to ensure source files remain free of `print` statements

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d0808b6f0833393f8fed4ec388056