### PR TITLE
Add tests for CurrencyConverterViewController

### DIFF
--- a/PesobluTests/ViewControllers/CurrencyConverterViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/CurrencyConverterViewControllerTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import Combine
+@testable import Pesoblu
+
+final class CurrencyConverterViewControllerTests: XCTestCase {
+    private var sut: CurrencyConverterViewController!
+    private var mockViewModel: MockCurrencyConverterViewModel!
+    private var mockCurrency: CurrencyItemMock!
+
+    override func setUp() {
+        super.setUp()
+        mockViewModel = MockCurrencyConverterViewModel()
+        mockCurrency = CurrencyItemMock(currencyTitle: "Mock", currencyLabel: "Mock", rate: "0")
+        sut = CurrencyConverterViewController(viewModel: mockViewModel, currency: mockCurrency)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockViewModel = nil
+        mockCurrency = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func test_viewDidLoad_configuresController() {
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(sut.title, "Convertir")
+        XCTAssertTrue(mockViewModel.updateCurrencyCalled)
+        XCTAssertTrue(mockViewModel.getConvertedValuesCalled)
+        XCTAssertTrue(sut.view is CurrencyConverterView)
+    }
+
+    @MainActor
+    func test_viewWillAppear_animatesView() {
+        sut.loadViewIfNeeded()
+        sut.view.alpha = 0.5
+        sut.view.transform = CGAffineTransform(scaleX: 2, y: 2)
+
+        sut.viewWillAppear(false)
+
+        XCTAssertEqual(sut.view.alpha, 1, accuracy: 0.001)
+        XCTAssertEqual(sut.view.transform, .identity)
+    }
+
+    @MainActor
+    func test_didTapBack_popsViewController() {
+        let nav = MockNavigationController(rootViewController: sut)
+
+        sut.didTapBack()
+
+        XCTAssertTrue(nav.didPopViewController)
+    }
+}
+
+private final class MockCurrencyConverterViewModel: CurrencyConverterViewModelProtocol {
+    var updateCurrencyCalled = false
+    var getConvertedValuesCalled = false
+
+    func getDolarBlue() async throws -> DolarBlue? { nil }
+    func checkPermission(dolar: String) {}
+    func getCurrencyArray() -> [String] { [] }
+    func updateCurrency(selectedCurrency: CurrencyItem) {
+        updateCurrencyCalled = true
+    }
+    func updateAmount(_ amount: Double?) {}
+    func getConvertedValues() -> AnyPublisher<(String, String, String, String), Never> {
+        getConvertedValuesCalled = true
+        return Just(("", "", "", "")).eraseToAnyPublisher()
+    }
+}
+
+private struct CurrencyItemMock: CurrencyItem {
+    var currencyTitle: String?
+    var currencyLabel: String?
+    var rate: String?
+}
+
+private final class MockNavigationController: UINavigationController {
+    var didPopViewController = false
+    override func popViewController(animated: Bool) -> UIViewController? {
+        didPopViewController = true
+        return super.popViewController(animated: animated)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for CurrencyConverterViewController
- verify title and viewModel bindings on viewDidLoad
- confirm animation changes and back navigation behavior

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689faeb1932883338bcfb1bcaf676df0