### PR TITLE
Refactor API key management to external config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment file
+API_KEY=YOUR_API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore sensitive configuration files
+Pesoblu/Resources/Secrets.plist
+.env
+
+# macOS files
+.DS_Store

--- a/Pesoblu/Resources/Secrets.plist.example
+++ b/Pesoblu/Resources/Secrets.plist.example
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>API_KEY</key>
+    <string>YOUR_API_KEY</string>
+</dict>
+</plist>

--- a/Pesoblu/Utils/APIConfig.swift
+++ b/Pesoblu/Utils/APIConfig.swift
@@ -1,7 +1,21 @@
 import Foundation
 
 struct APIConfig {
-    static let apiKey = "99f81f10b5b6b92679b9051bdce40b7647f150e0"
+    /// Retrieves the API key from a `Secrets.plist` file bundled with the app or from
+    /// the `API_KEY` environment variable. The actual `Secrets.plist` should not be
+    /// committed to version control.
+    static var apiKey: String {
+        if let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
+           let dict = NSDictionary(contentsOfFile: path) as? [String: Any],
+           let key = dict["API_KEY"] as? String {
+            return key
+        }
+        if let envKey = ProcessInfo.processInfo.environment["API_KEY"] {
+            return envKey
+        }
+        fatalError("API_KEY not found. Provide it in Secrets.plist or as an environment variable.")
+    }
+
     static let currencyBaseURL = "https://api.getgeoapi.com/v2/currency/convert"
     static let dolarAPIBaseURL = "https://dolarapi.com/v1/dolares"
     static var dolarBlueURL: String { "\(dolarAPIBaseURL)/blue" }

--- a/PesobluTests/APIConfigTests.swift
+++ b/PesobluTests/APIConfigTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Pesoblu
+
+final class APIConfigTests: XCTestCase {
+    func test_apiKeyLoadsFromEnvironment() {
+        let expected = "test_key"
+        setenv("API_KEY", expected, 1)
+        defer { unsetenv("API_KEY") }
+        XCTAssertEqual(APIConfig.apiKey, expected)
+    }
+}


### PR DESCRIPTION
## Summary
- load API key from `Secrets.plist` or `API_KEY` environment variable
- ignore sensitive configuration files and provide examples
- add unit test for API key injection via environment variable

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme Pesoblu -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2907f5d9483338d50fc03a5e6d9a8