### PR TITLE
Refactor concurrency to separate UI and network work

### DIFF
--- a/Pesoblu/Modules/Change/View/ChangeViewController.swift
+++ b/Pesoblu/Modules/Change/View/ChangeViewController.swift
@@ -48,7 +48,9 @@ class ChangeViewController: UIViewController  {
         super.viewDidLoad()
         
         setup()
-        viewModel.getChangeOfCurrencies()
+        Task {
+            await viewModel.getChangeOfCurrencies()
+        }
         setTitle()
     }
     

--- a/Pesoblu/Modules/Favorite/ViewModel/FavoriteViewModel.swift
+++ b/Pesoblu/Modules/Favorite/ViewModel/FavoriteViewModel.swift
@@ -8,8 +8,7 @@
 import Foundation
 import SwiftUI
 
-@MainActor
-class FavoriteViewModel: ObservableObject{
+class FavoriteViewModel: ObservableObject {
     private let coreDataService : CoreDataServiceProtocol
     private let placeService : PlaceServiceProtocol
     private let distanceService: DistanceServiceProtocol
@@ -47,9 +46,12 @@ class FavoriteViewModel: ObservableObject{
             do {
                 let favoriteIds = try await fetchAllFavoritesIds()
                 let allPlaces = try await fetchAllPlaces()
-                self.places = allPlaces.filter { favoriteIds.contains(String($0.id)) }
-                for place in places {
+                var filtered = allPlaces.filter { favoriteIds.contains(String($0.id)) }
+                for place in filtered {
                     place.distance = distanceService.getDistanceForPlace(place)
+                }
+                await MainActor.run {
+                    self.places = filtered
                 }
             } catch {
                 AppLogger.error("Error al cargar favoritos: \(error)")

--- a/Pesoblu/Modules/Home/View/HomeViewController.swift
+++ b/Pesoblu/Modules/Home/View/HomeViewController.swift
@@ -185,29 +185,36 @@ extension HomeViewController {
 }
 
 //MARK: - SetUp QuickConversor
-@MainActor
 extension HomeViewController {
     func setupQuickConversor() {
-        
-        Task { @MainActor in
-            do{
+        Task {
+            do {
                 if let dolarBlue = try await homeViewModel.getDolarBlue() {
-                    quickConversorView.setDolar(dolar: dolarBlue.venta)
+                    await MainActor.run {
+                        quickConversorView.setDolar(dolar: dolarBlue.venta)
+                    }
                 } else {
                     AppLogger.debug(NSLocalizedString("no_dollar_value", comment: ""))
                 }
                 let countryCode = homeViewModel.getUserCountry() ?? NSLocalizedString("default_country_code", comment: "")
                 let value = try await homeViewModel.getValueForCountry(countryCode: countryCode)
-                quickConversorView.setValue(value: value)
+                await MainActor.run {
+                    quickConversorView.setValue(value: value)
+                }
 
             } catch let error as APIError {
-                handleAPIError(error)
+                await MainActor.run {
+                    handleAPIError(error)
+                }
             } catch {
-                showAlert(message: String(format: NSLocalizedString("unknown_error", comment: ""), error.localizedDescription))
+                await MainActor.run {
+                    showAlert(message: String(format: NSLocalizedString("unknown_error", comment: ""), error.localizedDescription))
+                }
             }
         }
     }
-    
+
+    @MainActor
     private func handleAPIError(_ error: APIError) {
         switch error {
             case .invalidURL:
@@ -246,6 +253,7 @@ extension HomeViewController: CollectionViewSelectionDelegate {
         }
     }
 
+    @MainActor
     func showAlert(message: String) {
         alertPresenter.show(message: message, on: self)
     }

--- a/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
+++ b/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
@@ -83,53 +83,56 @@ class AuthenticationViewModel: AuthenticationViewModelProtocol{
 
 extension AuthenticationViewModel{
     
-    @MainActor //esto por llamar rootviewcontroller y window desde un hilo que no es el pricipal, por ello mainactor
-    func singInWithGoogle() async throws{
-        _authenticationState = .authenticating
+    func singInWithGoogle() async throws {
+        await MainActor.run {
+            _authenticationState = .authenticating
+        }
         guard let clientID = FirebaseApp.app()?.options.clientID else {
             fatalError("No Client ID found in Firebase Configuration")
         }
         let config = GIDConfiguration(clientID: clientID)
-        
         GIDSignIn.sharedInstance.configuration = config
-        
-        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let window = windowScene.windows.first,
-              let rootViewController = window.rootViewController else {
-            throw AuthError.unknown
-            //return false
+
+        let rootViewController: UIViewController = try await MainActor.run {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let window = windowScene.windows.first,
+                  let rootViewController = window.rootViewController else {
+                throw AuthError.unknown
+            }
+            return rootViewController
         }
-        
-        do{
-            let userAuthentication = try await GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController)
-            let user =  userAuthentication.user
+
+        do {
+            let userAuthentication = try await MainActor.run {
+                try await GIDSignIn.sharedInstance.signIn(withPresenting: rootViewController)
+            }
+            let user = userAuthentication.user
             guard let idToken = user.idToken else {
                 throw AuthenticationError.tokenError(message: "Id token missing")
             }
             let accessToken = user.accessToken
             let credential = GoogleAuthProvider.credential(withIDToken: idToken.tokenString, accessToken: accessToken.tokenString)
-            //usamos la credencial para loguearnos en firebase, toma la credencial y devuelve un usuario de firebase
             let result = try await Auth.auth().signIn(with: credential)
-            //Extraemos el usuario de result
             let firebaseUser = result.user
             let appUser = AppUser(firebaseUser: firebaseUser, preferredCurrency: nil)
             let existingUser = userService.loadUser()
             if existingUser?.uid != appUser.uid {
-                // Guardar solo si es un usuario nuevo o si hay cambios
                 userService.saveUser(appUser)
                 AppLogger.debug("AppUser saved to UserDefaults")
             } else {
                 AppLogger.debug("User already exists in UserDefaults")
             }
-            _authenticationState = .authenticated
-            onAuthenticationSuccess?()
-            
-        }
-        catch {
-            delegate?.showError(error)
+            await MainActor.run {
+                _authenticationState = .authenticated
+                onAuthenticationSuccess?()
+            }
+
+        } catch {
+            await MainActor.run {
+                delegate?.showError(error)
+            }
             throw error
         }
-        
     }
     
     func signOut() throws {

--- a/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
+++ b/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
@@ -200,27 +200,30 @@ extension PlaceViewController {
     }
     
     func loadFavoriteStatus() {
-
-        Task { @MainActor [weak self] in
+        Task { [weak self] in
             guard let self = self else { return }
             do {
-                self.isFavorite = try await self.placeViewModel.loadFavoriteStatus()
-            }
-            catch {
-                self.showAlert(title: "Error", message: "\(error.localizedDescription)")
+                let status = try await self.placeViewModel.loadFavoriteStatus()
+                await MainActor.run {
+                    self.isFavorite = status
+                }
+            } catch {
+                await MainActor.run {
+                    self.showAlert(title: "Error", message: "\(error.localizedDescription)")
+                }
             }
         }
     }
 
     func saveFavoriteStatus() {
-
-        Task { @MainActor [weak self] in
+        Task { [weak self] in
             guard let self = self else { return }
             do {
                 try await self.placeViewModel.saveFavoriteStatus(isFavorite: self.isFavorite)
-            }
-            catch {
-                self.showAlert(title: "Error", message: "Error saving favorite status: \(error.localizedDescription)")
+            } catch {
+                await MainActor.run {
+                    self.showAlert(title: "Error", message: "Error saving favorite status: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/PesobluTests/Change/ChangeCollectionViewTests.swift
+++ b/PesobluTests/Change/ChangeCollectionViewTests.swift
@@ -19,7 +19,7 @@ final class ChangeCollectionViewTests: XCTestCase {
             self.currencies = currencies
         }
 
-        func getChangeOfCurrencies() {
+        func getChangeOfCurrencies() async {
             delegate?.didFinish()
         }
 

--- a/PesobluTests/Change/ChangeViewControllerTests.swift
+++ b/PesobluTests/Change/ChangeViewControllerTests.swift
@@ -8,15 +8,16 @@ final class ChangeViewControllerTests: XCTestCase {
         var delegate: ChangeViewModelDelegate?
         var currencies: [CurrencyItem] = []
         private(set) var getChangeCalled = 0
-        func getChangeOfCurrencies() { getChangeCalled += 1 }
+        func getChangeOfCurrencies() async { getChangeCalled += 1 }
     }
 
-    func testViewDidLoadSetsUpCollectionViewAndStartsFetching() {
+    func testViewDidLoadSetsUpCollectionViewAndStartsFetching() async {
         let viewModel = MockViewModel()
         let collectionView = ChangeCollectionView(viewModel: viewModel)
         let sut = ChangeViewController(viewModel: viewModel, changeCView: collectionView)
 
         sut.loadViewIfNeeded()
+        await Task.yield()
 
         XCTAssertTrue(collectionView.delegate === sut)
         XCTAssertEqual(viewModel.getChangeCalled, 1)

--- a/PesobluTests/ViewModels/Change/ChangeViewModelTests.swift
+++ b/PesobluTests/ViewModels/Change/ChangeViewModelTests.swift
@@ -10,71 +10,51 @@ import XCTest
 @testable import Pesoblu
 
 final class ChangeViewModelTests: XCTestCase {
-    
+
     var viewModel: ChangeViewModel!
     var mockCurrencyService: MockCurrencyService!
-    var expectation: XCTestExpectation? // Declarar expectation como propiedad
-    var didFailCalled: Bool = false
+    var didFailCalled = false
+    var didFinishCalled = false
     var mockRates: Rates? = Rates(UYU: Uyu(rawRate: "40.0"), BRL: Brl(rawRate: "5.0"), CLP: Clp(rawRate: "900.0"))
-    
-    @MainActor override func setUp(){
+
+    override func setUp() {
         super.setUp()
         mockCurrencyService = MockCurrencyService()
         viewModel = ChangeViewModel(currencyService: mockCurrencyService, currencies: [], rates: Rates())
         viewModel.delegate = self
     }
-    
+
     override func tearDown() {
         viewModel = nil
         mockCurrencyService = nil
-        expectation = nil
         didFailCalled = false
+        didFinishCalled = false
         super.tearDown()
     }
-    
+
     // Prueba de éxito en fetchCurrencies
-    @MainActor
-    func testFetchCurrenciesSuccess() {
-        // Configurar el mock
+    func testFetchCurrenciesSuccess() async throws {
         mockCurrencyService.mockDolarMep = DolarMEP(currencyTitle: "title", currencyLabel: "label", moneda: "USD", casa: "Banco Central de Argentina", nombre: "Dolar Argentino MP", compra: 800.0, venta: 950.0, fechaActualizacion: "2025-05-26T00:00:00Z")
         mockCurrencyService.mockRates = Rates()
-        
-        expectation = XCTestExpectation(description: "Fetch currencies completes")
-        viewModel.delegate = self // Asegúrate de que el delegado esté configurado
-        
-        // Llamar al método asíncrono
-        viewModel.getChangeOfCurrencies()
-        
-        // Esperar a que la tarea asíncrona termine
-        wait(for: [expectation!], timeout: 1.0)
 
-        // Verificar resultados
+        try await viewModel.getChangeOfCurrencies()
+
         XCTAssertFalse(viewModel.currencies.isEmpty, "Currencies should not be empty")
         XCTAssertNotNil(viewModel.rates, "Rates should be set")
         XCTAssertEqual(viewModel.currencies.count, 1 + CurrencyCode.allCases.count, "Should have \(1 + CurrencyCode.allCases.count) currencies after conversion")
+        XCTAssertTrue(didFinishCalled)
     }
-    
+
     // Prueba de fallo en fetchCurrencies
-    @MainActor
-    func testFetchCurrenciesFailure() {
-        // Configurar el mock para fallar
+    func testFetchCurrenciesFailure() async {
         mockCurrencyService.shouldFail = true
-        
-        expectation = XCTestExpectation(description: "Fetch currencies fails")
-        didFailCalled = false
-        viewModel.delegate = self
-        
-        // Capturar el fallo
-        viewModel.getChangeOfCurrencies()
-        
-        // Esperar a que la tarea asíncrona termine
-        wait(for: [expectation!], timeout: 1.0)
+
+        await viewModel.getChangeOfCurrencies()
 
         XCTAssertTrue(didFailCalled, "didFail should be called on failure")
     }
 
-    @MainActor
-    func testGetChangeOfCurrenciesAppendsRatesAndNotifiesDelegate() {
+    func testGetChangeOfCurrenciesAppendsRatesAndNotifiesDelegate() async throws {
         let mep = DolarMEP(currencyTitle: nil,
                            currencyLabel: nil,
                            moneda: "USD",
@@ -89,20 +69,16 @@ final class ChangeViewModelTests: XCTestCase {
         rates.EUR = Eur(currencyTitle: nil, currencyLabel: nil, rawRate: "2")
         mockCurrencyService.mockRates = rates
 
-        expectation = XCTestExpectation(description: "didFinish")
-
-        viewModel.getChangeOfCurrencies()
-
-        wait(for: [expectation!], timeout: 1.0)
+        try await viewModel.getChangeOfCurrencies()
 
         XCTAssertEqual(viewModel.currencies.count, CurrencyCode.allCases.count + 1)
         XCTAssertEqual(viewModel.currencies.first?.currencyTitle, "USD MEP - Dólar Americano")
         XCTAssertEqual(viewModel.currencies.first?.currencyLabel, "Dólar Bolsa de Valores / MEP")
         let eurItem = viewModel.currencies.first { $0.currencyTitle == CurrencyCode.EUR.title }
         XCTAssertEqual(eurItem?.rate, "50.00")
+        XCTAssertTrue(didFinishCalled)
     }
-    
-    @MainActor
+
     func testGetCurrencyValue() {
         viewModel.rates = mockRates ?? Rates()
         let item = viewModel.getCurrencyValue(for: .UYU, currency: 950.0)
@@ -110,16 +86,14 @@ final class ChangeViewModelTests: XCTestCase {
         XCTAssertEqual(item.currencyTitle, "UYU - Peso Uruguayo")
         XCTAssertEqual(item.currencyLabel, "Uruguay")
     }
-
 }
 
 extension ChangeViewModelTests: ChangeViewModelDelegate {
     func didFinish() {
-        expectation?.fulfill() // Cumplir la expectativa
+        didFinishCalled = true
     }
 
     func didFail(error: Error) {
-        didFailCalled = true // Actualizar la variable
-        expectation?.fulfill() // Cumplir la expectativa
+        didFailCalled = true
     }
 }


### PR DESCRIPTION
## Summary
- remove `@MainActor` from network calls and update UI via `MainActor.run`
- run background tasks for favorites, authentication, and currency services
- convert change module tests to `async/await`

## Testing
- `xcodebuild -list -project Pesoblu.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a296990f408333b9c4337670c7295e