### PR TITLE
Manage timer lifecycle in CurrencyConverterViewController

### DIFF
--- a/PesobluTests/ViewControllers/CurrencyConverterViewControllerTests.swift
+++ b/PesobluTests/ViewControllers/CurrencyConverterViewControllerTests.swift
@@ -15,6 +15,7 @@ final class CurrencyConverterViewControllerTests: XCTestCase {
     }
 
     override func tearDown() {
+        sut.stopTimer()
         sut = nil
         mockViewModel = nil
         mockCurrency = nil
@@ -29,6 +30,9 @@ final class CurrencyConverterViewControllerTests: XCTestCase {
         XCTAssertTrue(mockViewModel.updateCurrencyCalled)
         XCTAssertTrue(mockViewModel.getConvertedValuesCalled)
         XCTAssertTrue(sut.view is CurrencyConverterView)
+        let timer = Mirror(reflecting: sut!).descendant("timer") as? Timer
+        XCTAssertNotNil(timer)
+        sut.stopTimer()
     }
 
     @MainActor
@@ -50,6 +54,14 @@ final class CurrencyConverterViewControllerTests: XCTestCase {
         sut.didTapBack()
 
         XCTAssertTrue(nav.didPopViewController)
+    }
+
+    @MainActor
+    func test_viewWillDisappear_invalidatesTimer() {
+        sut.startTimer()
+        sut.viewWillDisappear(false)
+        let timer = Mirror(reflecting: sut!).descendant("timer") as? Timer
+        XCTAssertNil(timer)
     }
 }
 


### PR DESCRIPTION
## Summary
- Use a 10-minute interval for currency refresh and store the Timer weakly
- Add `stopTimer` and call it in `viewWillDisappear`
- Expand controller tests to verify timer start and invalidation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Pesoblu.xcodeproj -scheme Pesoblu -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37112348483339859cbb4b1f81eb6