### PR TITLE
Localize favorites view strings and improve view model

### DIFF
--- a/Pesoblu/Modules/Favorite/View/FavoritesView.swift
+++ b/Pesoblu/Modules/Favorite/View/FavoritesView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FavoritesView: View {
     
-    @StateObject var viewModel: FavoriteViewModel
+    @StateObject private var viewModel: FavoriteViewModel
     private let onSelect: (PlaceItem) -> Void
     
     private let columns = [GridItem(.flexible())]
@@ -25,18 +25,18 @@ struct FavoritesView: View {
                 emptyState
             } else{
                 LazyVGrid(columns: columns, spacing: 12) {
-                    ForEach(viewModel.places, id: \.id){ places in
-                        FavoritesItemView(place: places){
-                            onSelect(places)
+                    ForEach(viewModel.places, id: \.id) { place in
+                        FavoritesItemView(place: place) {
+                            onSelect(place)
                         }
                     }
                 }
                 .padding(.horizontal)
             }
-            
+
         }
         .background(Color(UIColor(hex: "F0F8FF")))
-        .navigationTitle(Text("Favoritos"))
+        .navigationTitle("favorites_title")
         .task{
             viewModel.loadFavorites()
         }
@@ -46,7 +46,7 @@ struct FavoritesView: View {
             Image(systemName: "heart")
                 .font(.system(size: 48))
                 .foregroundColor(.pink)
-            Text("No tenés favoritos aún")
+            Text("no_favorites_yet")
                 .font(.headline)
                 .foregroundColor(.secondary)
         }

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Wechselkurse";
 "buy_label" = "Kauf";
 "login_screen_name" = "Anmeldebildschirm";
+"favorites_title" = "Favoriten";
+"no_favorites_yet" = "Du hast noch keine Favoriten";

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Exchange Rates";
 "buy_label" = "Buy";
 "login_screen_name" = "Login Screen";
+"favorites_title" = "Favorites";
+"no_favorites_yet" = "You don't have any favorites yet";

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Cotización";
 "buy_label" = "Compra";
 "login_screen_name" = "Pantalla de inicio de sesión";
+"favorites_title" = "Favoritos";
+"no_favorites_yet" = "No tenés favoritos aún";

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Taux de change";
 "buy_label" = "Achat";
 "login_screen_name" = "Écran de connexion";
+"favorites_title" = "Favoris";
+"no_favorites_yet" = "Vous n'avez pas encore de favoris";

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "שערי חליפין";
 "buy_label" = "קנה";
 "login_screen_name" = "מסך התחברות";
+"favorites_title" = "מועדפים";
+"no_favorites_yet" = "אין לך מועדפים עדיין";

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Cambio";
 "buy_label" = "Acquisto";
 "login_screen_name" = "Schermata di accesso";
+"favorites_title" = "Preferiti";
+"no_favorites_yet" = "Non hai ancora preferiti";

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "為替レート";
 "buy_label" = "購入";
 "login_screen_name" = "ログイン画面";
+"favorites_title" = "お気に入り";
+"no_favorites_yet" = "お気に入りはまだありません";

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Cotações";
 "buy_label" = "Compra";
 "login_screen_name" = "Tela de login";
+"favorites_title" = "Favoritos";
+"no_favorites_yet" = "Você ainda não tem favoritos";

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -118,3 +118,5 @@
 "exchange_rate_title" = "Курсы обмена";
 "buy_label" = "Покупка";
 "login_screen_name" = "Экран входа";
+"favorites_title" = "Избранное";
+"no_favorites_yet" = "У вас ещё нет избранного";


### PR DESCRIPTION
## Summary
- convert FavoritesView to hold its ViewModel as a `@StateObject`
- rename loop variable for clarity
- localize favorites title and empty state message

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project Pesoblu.xcodeproj -scheme Pesoblu test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a8886e44b88333b5f5e390e5d502d6