### PR TITLE
Localize AuthError descriptions

### DIFF
--- a/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
+++ b/Pesoblu/Modules/Login/ViewModel/AuthenticationViewModel.swift
@@ -57,22 +57,22 @@ class AuthenticationViewModel: AuthenticationViewModelProtocol{
         case tokenError(message: String)
     }
     
-    enum AuthError: Error {
+    enum AuthError: LocalizedError {
         case networkError
         case invalidCredentials
         case userCancelled
         case unknown
-        
-        var localizedDescription: String {
+
+        var errorDescription: String? {
             switch self {
             case .networkError:
-                return "No hay conexión a Internet."
+                return NSLocalizedString("network_error", comment: "No internet connection")
             case .invalidCredentials:
-                return "Las credenciales son inválidas."
+                return NSLocalizedString("invalid_credentials", comment: "Invalid credentials")
             case .userCancelled:
-                return "El usuario canceló el inicio de sesión."
+                return NSLocalizedString("user_cancelled", comment: "User cancelled login")
             case .unknown:
-                return "Ocurrió un error desconocido."
+                return NSLocalizedString("unknown_auth_error", comment: "Unknown authentication error")
             }
         }
     }

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Favoriten";
 "no_favorites_yet" = "Du hast noch keine Favoriten";
 "image_placeholder" = "Bild des Ortes";
+"network_error" = "Keine Internetverbindung.";
+"invalid_credentials" = "Ungültige Anmeldedaten.";
+"user_cancelled" = "Der Benutzer hat die Anmeldung abgebrochen.";
+"unknown_auth_error" = "Ein unbekannter Fehler ist aufgetreten.";

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Favorites";
 "no_favorites_yet" = "You don't have any favorites yet";
 "image_placeholder" = "Place image";
+"network_error" = "No Internet connection.";
+"invalid_credentials" = "Invalid credentials.";
+"user_cancelled" = "User canceled login.";
+"unknown_auth_error" = "An unknown error occurred.";

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Favoritos";
 "no_favorites_yet" = "No tenés favoritos aún";
 "image_placeholder" = "Imagen de lugar";
+"network_error" = "No hay conexión a Internet.";
+"invalid_credentials" = "Las credenciales son inválidas.";
+"user_cancelled" = "El usuario canceló el inicio de sesión.";
+"unknown_auth_error" = "Ocurrió un error desconocido.";

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Favoris";
 "no_favorites_yet" = "Vous n'avez pas encore de favoris";
 "image_placeholder" = "Image du lieu";
+"network_error" = "Pas de connexion Internet.";
+"invalid_credentials" = "Identifiants invalides.";
+"user_cancelled" = "L'utilisateur a annulé la connexion.";
+"unknown_auth_error" = "Une erreur inconnue est survenue.";

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "מועדפים";
 "no_favorites_yet" = "אין לך מועדפים עדיין";
 "image_placeholder" = "תמונת המקום";
+"network_error" = "אין חיבור לאינטרנט.";
+"invalid_credentials" = "פרטי הזדהות שגויים.";
+"user_cancelled" = "המשתמש ביטל את ההתחברות.";
+"unknown_auth_error" = "אירעה שגיאה לא ידועה.";

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Preferiti";
 "no_favorites_yet" = "Non hai ancora preferiti";
 "image_placeholder" = "Immagine del luogo";
+"network_error" = "Nessuna connessione Internet.";
+"invalid_credentials" = "Credenziali non valide.";
+"user_cancelled" = "L'utente ha annullato l'accesso.";
+"unknown_auth_error" = "Si è verificato un errore sconosciuto.";

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "お気に入り";
 "no_favorites_yet" = "お気に入りはまだありません";
 "image_placeholder" = "場所の画像";
+"network_error" = "インターネットに接続されていません。";
+"invalid_credentials" = "認証情報が無効です。";
+"user_cancelled" = "ユーザーがログインをキャンセルしました。";
+"unknown_auth_error" = "不明なエラーが発生しました。";

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Favoritos";
 "no_favorites_yet" = "Você ainda não tem favoritos";
 "image_placeholder" = "Imagem do lugar";
+"network_error" = "Sem conexão com a Internet.";
+"invalid_credentials" = "Credenciais inválidas.";
+"user_cancelled" = "O usuário cancelou o login.";
+"unknown_auth_error" = "Ocorreu um erro desconhecido.";

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -121,3 +121,7 @@
 "favorites_title" = "Избранное";
 "no_favorites_yet" = "У вас ещё нет избранного";
 "image_placeholder" = "Изображение места";
+"network_error" = "Нет подключения к Интернету.";
+"invalid_credentials" = "Неверные учетные данные.";
+"user_cancelled" = "Пользователь отменил вход.";
+"unknown_auth_error" = "Произошла неизвестная ошибка.";


### PR DESCRIPTION
## Summary
- Conform `AuthError` to `LocalizedError` and provide localized `errorDescription`
- Add translations for authentication error messages across supported languages
- Use `error.localizedDescription` when logging or presenting authentication errors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b08b69ed788333959b3a3c61c0311e