### PR TITLE
Localize PlaceViewController error messages

### DIFF
--- a/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
+++ b/Pesoblu/Modules/PlaceView/View/PlaceViewController.swift
@@ -16,7 +16,7 @@ protocol AlertPresenterProtocol  {
 struct DefaultAlertPresenter: AlertPresenterProtocol  {
     func present(on viewController: UIViewController, title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("ok_action", comment: ""), style: .default))
         viewController.present(alert, animated: true)
     }
 }
@@ -163,7 +163,8 @@ extension PlaceViewController {
 
 extension PlaceViewController: PlaceViewDelegate {
     func didFailToOpenMaps() {
-        showAlert(title: "ERROR", message: "No se pudo abrir maps.")
+        showAlert(title: NSLocalizedString("error_title", comment: ""),
+                  message: NSLocalizedString("maps_open_error", comment: ""))
     }
     
     func didFailToOpenInstagram(title: String, message: String) {
@@ -171,11 +172,13 @@ extension PlaceViewController: PlaceViewDelegate {
     }
     
     func didFailToCall() {
-        showAlert(title: "Error de Llamada", message: "No se puede realizar la llamada. Verifica el número o el dispositivo.")
+        showAlert(title: NSLocalizedString("call_error_title", comment: ""),
+                  message: NSLocalizedString("call_error_message", comment: ""))
     }
-    
+
     func didFailToLoadImage(_ view: PlaceView, error: any Error) {
-        showAlert(title: "Error de Imagen", message: "Error al cargar imagen. Intente nuevamente mas tarde.")
+        showAlert(title: NSLocalizedString("image_error_title", comment: ""),
+                  message: NSLocalizedString("image_error_message", comment: ""))
     }
     
     
@@ -209,7 +212,8 @@ extension PlaceViewController {
                 }
             } catch {
                 await MainActor.run {
-                    self.showAlert(title: "Error", message: "\(error.localizedDescription)")
+                    self.showAlert(title: NSLocalizedString("error_title", comment: ""),
+                                   message: error.localizedDescription)
                 }
             }
         }
@@ -222,7 +226,8 @@ extension PlaceViewController {
                 try await self.placeViewModel.saveFavoriteStatus(isFavorite: self.isFavorite)
             } catch {
                 await MainActor.run {
-                    self.showAlert(title: "Error", message: "Error saving favorite status: \(error.localizedDescription)")
+                    self.showAlert(title: NSLocalizedString("error_title", comment: ""),
+                                   message: String(format: NSLocalizedString("favorite_save_error", comment: ""), error.localizedDescription))
                 }
             }
         }

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "Ungültige Instagram-URL.";
 "username_not_found" = "Benutzername nicht gefunden.";
 "cannot_open_instagram_or_safari" = "Instagram oder Safari kann nicht geöffnet werden.";
+"maps_open_error" = "Karten konnten nicht geöffnet werden.";
+"call_error_title" = "Anruffehler";
+"call_error_message" = "Der Anruf kann nicht durchgeführt werden. Überprüfen Sie die Nummer oder das Gerät.";
+"favorite_save_error" = "Fehler beim Speichern des Favoritenstatus: %@";

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "Invalid Instagram URL.";
 "username_not_found" = "Username not found.";
 "cannot_open_instagram_or_safari" = "Cannot open Instagram or Safari.";
+"maps_open_error" = "Could not open maps.";
+"call_error_title" = "Call Error";
+"call_error_message" = "Cannot make the call. Check the number or device.";
+"favorite_save_error" = "Error saving favorite status: %@";

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "URL de Instagram inválida.";
 "username_not_found" = "No se encontró nombre de usuario.";
 "cannot_open_instagram_or_safari" = "No se puede abrir Instagram ni Safari.";
+"maps_open_error" = "No se pudo abrir Maps.";
+"call_error_title" = "Error de Llamada";
+"call_error_message" = "No se puede realizar la llamada. Verifica el número o el dispositivo.";
+"favorite_save_error" = "Error guardando el estado de favorito: %@";

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "URL Instagram invalide.";
 "username_not_found" = "Nom d'utilisateur introuvable.";
 "cannot_open_instagram_or_safari" = "Impossible d'ouvrir Instagram ni Safari.";
+"maps_open_error" = "Impossible d'ouvrir Plans.";
+"call_error_title" = "Erreur d'appel";
+"call_error_message" = "Impossible de passer l'appel. Vérifiez le numéro ou l'appareil.";
+"favorite_save_error" = "Erreur lors de l'enregistrement de l'état du favori : %@";

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "כתובת אינסטגרם לא תקינה.";
 "username_not_found" = "שם המשתמש לא נמצא.";
 "cannot_open_instagram_or_safari" = "לא ניתן לפתוח אינסטגרם או ספארי.";
+"maps_open_error" = "לא ניתן לפתוח את המפות.";
+"call_error_title" = "שגיאת שיחה";
+"call_error_message" = "לא ניתן לבצע את השיחה. בדוק את המספר או את המכשיר.";
+"favorite_save_error" = "שגיאה בשמירת מצב המועדף: %@";

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "URL di Instagram non valida.";
 "username_not_found" = "Nome utente non trovato.";
 "cannot_open_instagram_or_safari" = "Impossibile aprire Instagram o Safari.";
+"maps_open_error" = "Impossibile aprire Mappe.";
+"call_error_title" = "Errore di chiamata";
+"call_error_message" = "Impossibile effettuare la chiamata. Controlla il numero o il dispositivo.";
+"favorite_save_error" = "Errore nel salvare lo stato preferito: %@";

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "無効なInstagramのURLです。";
 "username_not_found" = "ユーザー名が見つかりません。";
 "cannot_open_instagram_or_safari" = "InstagramまたはSafariを開けません。";
+"maps_open_error" = "マップを開けませんでした。";
+"call_error_title" = "通話エラー";
+"call_error_message" = "通話を行えません。番号またはデバイスを確認してください。";
+"favorite_save_error" = "お気に入りの状態を保存中にエラーが発生しました: %@";

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "URL do Instagram inválida.";
 "username_not_found" = "Nome de usuário não encontrado.";
 "cannot_open_instagram_or_safari" = "Não é possível abrir o Instagram nem o Safari.";
+"maps_open_error" = "Não foi possível abrir o mapa.";
+"call_error_title" = "Erro de chamada";
+"call_error_message" = "Não é possível realizar a chamada. Verifique o número ou o dispositivo.";
+"favorite_save_error" = "Erro ao salvar o status de favorito: %@";

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -132,3 +132,7 @@
 "invalid_instagram_url" = "Недействительный URL Instagram.";
 "username_not_found" = "Имя пользователя не найдено.";
 "cannot_open_instagram_or_safari" = "Невозможно открыть Instagram или Safari.";
+"maps_open_error" = "Не удалось открыть карты.";
+"call_error_title" = "Ошибка вызова";
+"call_error_message" = "Не удалось совершить звонок. Проверьте номер или устройство.";
+"favorite_save_error" = "Ошибка сохранения статуса избранного: %@";


### PR DESCRIPTION
## Summary
- Localize default alert button text
- Replace hardcoded error strings in `PlaceViewController` with `NSLocalizedString`
- Add new localization keys for map opening, call errors, and favorite status saving across all languages

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc12a33483338bff2e506d3838f1