### PR TITLE
Localize places list titles and error message

### DIFF
--- a/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
+++ b/Pesoblu/Modules/PlacesList/View/PlacesListViewController.swift
@@ -23,7 +23,10 @@ final class PlacesListViewController: UIViewController  {
         guard let placesListView = view as? PlacesListView else {
             AppLogger.error("Expected view to be of type PlacesListView")
             let errorVC = ErrorViewController(
-                message: "Failed to load view."
+                message: NSLocalizedString(
+                    "places_list_view_load_error_message",
+                    comment: "Error message when PlacesListView fails to load"
+                )
             )
             DispatchQueue.main.async { [weak self] in
                 self?.present(errorVC, animated: true)
@@ -61,7 +64,13 @@ final class PlacesListViewController: UIViewController  {
         super.viewDidLoad()
         navigationController?.navigationBar.prefersLargeTitles = false
 
-        navigationItem.title = "Lugares en \(selectedCity)"
+        navigationItem.title = String(
+            format: NSLocalizedString(
+                "places_in_city_title",
+                comment: "Navigation title for places in a specific city"
+            ),
+            selectedCity
+        )
       
         let backButton = UIBarButtonItem(image: UIImage(named: "nav-arrow-left"), style: .plain, target: self, action: #selector(didTapBack))
         backButton.tintColor = .black

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Bildfehler";
 /* Message for the image loading error alert */
 "image_error_message" = "Bild konnte nicht geladen werden. Bitte später erneut versuchen";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Orte in %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Ansicht konnte nicht geladen werden.";
 /* Title for the filters section */
 "filters_title" = "Filter";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Image Error";
 /* Message for the image loading error alert */
 "image_error_message" = "Could not load the image. Please try again later.";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Places in %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Failed to load view.";
 /* Title for the filters section */
 "filters_title" = "Filters";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Error de Imagen";
 /* Message for the image loading error alert */
 "image_error_message" = "No se pudo cargar la imagen. Intente nuevamente mas tarde";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Lugares en %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Error al cargar la vista.";
 /* Title for the filters section */
 "filters_title" = "Filtros";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Erreur d'image";
 /* Message for the image loading error alert */
 "image_error_message" = "Impossible de charger l'image. Veuillez réessayer plus tard.";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Lieux à %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Échec du chargement de la vue.";
 /* Title for the filters section */
 "filters_title" = "Filtres";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "שגיאת תמונה";
 /* Message for the image loading error alert */
 "image_error_message" = "לא ניתן היה לטעון את התמונה. נסה שוב מאוחר יותר.";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "מקומות ב%@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "טעינת התצוגה נכשלה.";
 /* Title for the filters section */
 "filters_title" = "מסננים";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Errore immagine";
 /* Message for the image loading error alert */
 "image_error_message" = "Impossibile caricare l'immagine. Riprova più tardi";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Luoghi a %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Impossibile caricare la vista.";
 /* Title for the filters section */
 "filters_title" = "Filtri";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "画像エラー";
 /* Message for the image loading error alert */
 "image_error_message" = "画像を読み込めませんでした。後でもう一度お試しください。";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "%@の場所";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "ビューの読み込みに失敗しました。";
 /* Title for the filters section */
 "filters_title" = "フィルター";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Erro de imagem";
 /* Message for the image loading error alert */
 "image_error_message" = "Não foi possível carregar a imagem. Tente novamente mais tarde.";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Lugares em %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Falha ao carregar a visualização.";
 /* Title for the filters section */
 "filters_title" = "Filtros";
 /* Label shown above the places list */

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -31,6 +31,10 @@
 "image_error_title" = "Ошибка изображения";
 /* Message for the image loading error alert */
 "image_error_message" = "Не удалось загрузить изображение. Пожалуйста, попробуйте позже.";
+/* Navigation title showing places in a selected city */
+"places_in_city_title" = "Места в %@";
+/* Error message when failing to load PlacesListView */
+"places_list_view_load_error_message" = "Не удалось загрузить представление.";
 /* Title for the filters section */
 "filters_title" = "Фильтры";
 /* Label shown above the places list */


### PR DESCRIPTION
## Summary
- localize dynamic navigation title in PlacesListViewController
- add NSLocalizedString usage for view loading error
- provide translations for new keys across Localizable.strings files

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fc13957083338c2f93ac8f84fbec