### PR TITLE
Localize currency converter strings

### DIFF
--- a/Pesoblu/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
+++ b/Pesoblu/Modules/CurrencyConverter/View/CurrencyConverterViewController.swift
@@ -128,7 +128,7 @@ extension CurrencyConverterViewController  {
             .sink { [weak self] (currencyFromPeso, currencyToPeso, fromDolarToCurrency, currencyToDolarValue) in
                 guard let self = self else { return }
 
-                if self.selectedCurrency.currencyLabel == "Dólar Bolsa de Valores / MEP" {
+                if self.selectedCurrency.currencyLabel == NSLocalizedString("dolar_mep_label", comment: "") {
                     self.converterView.updateValues(
                         fromPeso: currencyToDolarValue,
                         toPeso: fromDolarToCurrency,

--- a/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyConverterView.swift
+++ b/Pesoblu/Modules/CurrencyConverter/View/SubViews/CurrencyConverterView.swift
@@ -51,7 +51,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var quantitytextfield : UITextField = {
         var text = UITextField()
-        text.placeholder = "Ingrese la cantidad de dinero a convertir"
+        text.placeholder = NSLocalizedString("currency_converter_amount_placeholder", comment: "")
         text.textAlignment = .center
         text.textColor = .black
         text.backgroundColor = .white
@@ -99,7 +99,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var toPesoTitle: UILabel = {
         var label = UILabel()
-        label.text = "Compra"
+        label.text = NSLocalizedString("buy_label", comment: "")
         label.textColor = .systemBlue
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         label.textAlignment = .center
@@ -110,7 +110,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var toPesoValue: UILabel = {
         var label = UILabel()
-        label.text = "0.00"
+        label.text = NSLocalizedString("default_amount_value", comment: "")
         label.textColor = .systemBlue
         label.font = .boldSystemFont(ofSize: 22)
         label.textAlignment = .center
@@ -135,7 +135,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var fromPesoTitle: UILabel = {
         var label = UILabel()
-        label.text = "En Dolares"
+        label.text = NSLocalizedString("in_dollars_label", comment: "")
         label.textColor = .systemGreen
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         label.textAlignment = .center
@@ -146,7 +146,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var fromPesoValue: UILabel = {
         var label = UILabel()
-        label.text = "0.00"
+        label.text = NSLocalizedString("default_amount_value", comment: "")
         label.textColor = .systemGreen
         label.font = .boldSystemFont(ofSize: 22)
         label.textAlignment = .center
@@ -171,7 +171,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var toDolarTitle: UILabel = {
         var label = UILabel()
-        label.text = "Compra"
+        label.text = NSLocalizedString("buy_label", comment: "")
         label.textColor = .systemIndigo
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         label.textAlignment = .center
@@ -182,7 +182,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var toDolarValue: UILabel = {
         var label = UILabel()
-        label.text = "0.00"
+        label.text = NSLocalizedString("default_amount_value", comment: "")
         label.textColor = .systemIndigo
         label.font = .boldSystemFont(ofSize: 22)
         label.textAlignment = .center
@@ -207,7 +207,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var fromDolarTitle: UILabel = {
         var label = UILabel()
-        label.text = "En Dolares"
+        label.text = NSLocalizedString("in_dollars_label", comment: "")
         label.textColor = .systemOrange
         label.font = UIFont.systemFont(ofSize: 18, weight: .medium)
         label.textAlignment = .center
@@ -218,7 +218,7 @@ final class CurrencyConverterView: UIView  {
     
     private lazy var fromDolarValue: UILabel = {
         var label = UILabel()
-        label.text = "0.00"
+        label.text = NSLocalizedString("default_amount_value", comment: "")
         label.textColor = .systemOrange
         label.font = .boldSystemFont(ofSize: 22)
         label.textAlignment = .center
@@ -426,24 +426,27 @@ extension CurrencyConverterView: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let maxCharacters = 10
 
+        let decimalComma = NSLocalizedString("decimal_comma", comment: "")
+        let decimalPoint = NSLocalizedString("decimal_point", comment: "")
+
         // Si el usuario escribe una coma, la reemplazamos por punto
-        if string == "," {
+        if string == decimalComma {
             if let currentText = textField.text as NSString? {
-                let updatedText = currentText.replacingCharacters(in: range, with: ".")
+                let updatedText = currentText.replacingCharacters(in: range, with: decimalPoint)
                 textField.text = updatedText
             }
             return false
         }
 
         // Validar que el string ingresado contenga solo números o un punto
-        let allowedCharacters = CharacterSet(charactersIn: "0123456789.")
+        let allowedCharacters = CharacterSet.decimalDigits.union(CharacterSet(charactersIn: decimalPoint))
         let characterSet = CharacterSet(charactersIn: string)
         let isValidInput = allowedCharacters.isSuperset(of: characterSet)
 
         // Validar que no haya más de un punto decimal
         if let currentText = textField.text as NSString? {
             let updatedText = currentText.replacingCharacters(in: range, with: string)
-            let containsMultipleDots = updatedText.components(separatedBy: ".").count > 2
+            let containsMultipleDots = updatedText.components(separatedBy: decimalPoint).count > 2
             return updatedText.count <= maxCharacters && isValidInput && !containsMultipleDots
         }
 
@@ -457,10 +460,11 @@ extension CurrencyConverterView: UITextFieldDelegate {
 extension CurrencyConverterView {
     
     func resetControls() {
-        toPesoValue.text = "0.00"
-        fromPesoValue.text = "0.00"
-        toDolarValue.text = "0.00"
-        fromDolarValue.text = "0.00"
+        let defaultAmount = NSLocalizedString("default_amount_value", comment: "")
+        toPesoValue.text = defaultAmount
+        fromPesoValue.text = defaultAmount
+        toDolarValue.text = defaultAmount
+        fromDolarValue.text = defaultAmount
     }
     
 }

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Anruffehler";
 "call_error_message" = "Der Anruf kann nicht durchgeführt werden. Überprüfen Sie die Nummer oder das Gerät.";
 "favorite_save_error" = "Fehler beim Speichern des Favoritenstatus: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Call Error";
 "call_error_message" = "Cannot make the call. Check the number or device.";
 "favorite_save_error" = "Error saving favorite status: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Error de Llamada";
 "call_error_message" = "No se puede realizar la llamada. Verifica el número o el dispositivo.";
 "favorite_save_error" = "Error guardando el estado de favorito: %@";
+"currency_converter_amount_placeholder" = "Ingrese la cantidad de dinero a convertir";
+"in_dollars_label" = "En Dólares";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Erreur d'appel";
 "call_error_message" = "Impossible de passer l'appel. Vérifiez le numéro ou l'appareil.";
 "favorite_save_error" = "Erreur lors de l'enregistrement de l'état du favori : %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "שגיאת שיחה";
 "call_error_message" = "לא ניתן לבצע את השיחה. בדוק את המספר או את המכשיר.";
 "favorite_save_error" = "שגיאה בשמירת מצב המועדף: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Errore di chiamata";
 "call_error_message" = "Impossibile effettuare la chiamata. Controlla il numero o il dispositivo.";
 "favorite_save_error" = "Errore nel salvare lo stato preferito: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "通話エラー";
 "call_error_message" = "通話を行えません。番号またはデバイスを確認してください。";
 "favorite_save_error" = "お気に入りの状態を保存中にエラーが発生しました: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Erro de chamada";
 "call_error_message" = "Não é possível realizar a chamada. Verifique o número ou o dispositivo.";
 "favorite_save_error" = "Erro ao salvar o status de favorito: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -140,3 +140,9 @@
 "call_error_title" = "Ошибка вызова";
 "call_error_message" = "Не удалось совершить звонок. Проверьте номер или устройство.";
 "favorite_save_error" = "Ошибка сохранения статуса избранного: %@";
+"currency_converter_amount_placeholder" = "Enter the amount to convert";
+"in_dollars_label" = "In Dollars";
+"dolar_mep_label" = "Dólar Bolsa de Valores / MEP";
+"decimal_comma" = ",";
+"decimal_point" = ".";
+"default_amount_value" = "0.00";


### PR DESCRIPTION
## Summary
- Replace hard-coded text in currency converter view with localized keys
- Localize string comparison for MEP currency handling
- Extend Localizable.strings with new currency converter keys

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b604d033d88333bfb22165dad45351