### PR TITLE
Use system locale for currency formatting

### DIFF
--- a/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
+++ b/Pesoblu/Modules/Change/View/SubViews/ChangeView.swift
@@ -104,7 +104,7 @@ class ChangeView: UIView  {
 
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
-        formatter.locale = Locale(identifier: "es_AR")
+        formatter.locale = Locale.current
 
         if let value = Double(valueBuy) {
             currencyValueLabel.text = formatter.string(from: NSNumber(value: value))


### PR DESCRIPTION
## Summary
- replace hard-coded `es_AR` locale with `Locale.current` in ChangeView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Pesoblu.xcodeproj -scheme Pesoblu` *(fails: command not found)*
- `swift -e 'import Foundation; let formatter = NumberFormatter(); formatter.numberStyle = .currency; formatter.locale = Locale.current; print("Current: \(formatter.string(from: 1234.56) ?? "nil")")'`


------
https://chatgpt.com/codex/tasks/task_e_68b606af1c708333aca558e38eea1626