### PR TITLE
Localize retry button label

### DIFF
--- a/Pesoblu/Modules/Error/ErrorViewController.swift
+++ b/Pesoblu/Modules/Error/ErrorViewController.swift
@@ -33,7 +33,7 @@ final class ErrorViewController: UIViewController {
         label.translatesAutoresizingMaskIntoConstraints = false
 
         let button = UIButton(type: .system)
-        button.setTitle("Retry", for: .normal)
+        button.setTitle(NSLocalizedString("retry_button", comment: ""), for: .normal)
         button.addTarget(self, action: #selector(didTapRetry), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
 

--- a/Pesoblu/Resources/de.lproj/Localizable.strings
+++ b/Pesoblu/Resources/de.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Erneut versuchen";

--- a/Pesoblu/Resources/en.lproj/Localizable.strings
+++ b/Pesoblu/Resources/en.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Retry";

--- a/Pesoblu/Resources/es.lproj/Localizable.strings
+++ b/Pesoblu/Resources/es.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Reintentar";

--- a/Pesoblu/Resources/fr.lproj/Localizable.strings
+++ b/Pesoblu/Resources/fr.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Réessayer";

--- a/Pesoblu/Resources/he.lproj/Localizable.strings
+++ b/Pesoblu/Resources/he.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "נסה שוב";

--- a/Pesoblu/Resources/it.lproj/Localizable.strings
+++ b/Pesoblu/Resources/it.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Riprova";

--- a/Pesoblu/Resources/ja.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ja.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "再試行";

--- a/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
+++ b/Pesoblu/Resources/pt-BR.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Tentar novamente";

--- a/Pesoblu/Resources/ru.lproj/Localizable.strings
+++ b/Pesoblu/Resources/ru.lproj/Localizable.strings
@@ -176,3 +176,5 @@
 "decimal_comma" = ",";
 "decimal_point" = ".";
 "default_amount_value" = "0.00";
+
+"retry_button" = "Повторить";


### PR DESCRIPTION
## Summary
- use localized string for retry button in ErrorViewController
- add `retry_button` translations for all supported languages

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68b6095340dc83338232131b73323a72