### PR TITLE
Localize tab titles in coordinators

### DIFF
--- a/Pesoblu/Coordinators/ChangeCoordinator.swift
+++ b/Pesoblu/Coordinators/ChangeCoordinator.swift
@@ -26,9 +26,10 @@ class ChangeCoordinator: Coordinator {
         vc.onSelectCurrency = { [weak self] selectedCurrency in
             self?.showCurrencyConverter(currencyItem: selectedCurrency)
         }
-        
-        vc.title = "Cotización"
-        vc.tabBarItem = UITabBarItem(title: "Cotización", image: UIImage(named: "exchange-01"), tag: 1)
+
+        let title = NSLocalizedString("exchange_rate_title", comment: "")
+        vc.title = title
+        vc.tabBarItem = UITabBarItem(title: title, image: UIImage(named: "exchange-01"), tag: 1)
         navigationController.setViewControllers([vc], animated: false)
     }
     

--- a/Pesoblu/Coordinators/FavoriteCoordinator.swift
+++ b/Pesoblu/Coordinators/FavoriteCoordinator.swift
@@ -38,11 +38,11 @@ class FavoriteCoordinator: Coordinator{
         let favoriteView = FavoritesView(viewModel: viewModel) { [weak self] place in
             self?.showPlaceDetail(place)
         }
-        
+
         let hostingVC = UIHostingController(rootView: favoriteView)
-        let favoritesTitle = NSLocalizedString("favorites_title", comment: "")
-        hostingVC.title = favoritesTitle
-        hostingVC.tabBarItem = UITabBarItem(title: favoritesTitle, image: UIImage(systemName: "heart"), tag: 2)
+        let title = NSLocalizedString("favorites_title", comment: "")
+        hostingVC.title = title
+        hostingVC.tabBarItem = UITabBarItem(title: title, image: UIImage(systemName: "heart"), tag: 2)
         navigationController.setViewControllers([hostingVC], animated: true)
     }
     

--- a/Pesoblu/Coordinators/HomeCoordinator.swift
+++ b/Pesoblu/Coordinators/HomeCoordinator.swift
@@ -23,13 +23,14 @@ final class HomeCoordinator: Coordinator {
             cityDataService: CityDataService()
         )
         let vc = HomeViewController(homeViewModel: viewModel)
-        
+
         vc.setOnSelect { [weak self] selectedPlaces, selectedCity, placeType in
             self?.showPlacesListWithCity(selectedPlaces: selectedPlaces, selectedCity: selectedCity, placeType: placeType)
         }
-        
-        vc.title = "Home"
-        vc.tabBarItem = UITabBarItem(title: "Home", image: UIImage(named: "home-01"), tag: 0)
+
+        let title = NSLocalizedString("home_title", comment: "")
+        vc.title = title
+        vc.tabBarItem = UITabBarItem(title: title, image: UIImage(named: "home-01"), tag: 0)
         navigationController.setViewControllers([vc], animated: false)
     }
     

--- a/Pesoblu/Coordinators/ProfileCoordinator.swift
+++ b/Pesoblu/Coordinators/ProfileCoordinator.swift
@@ -31,8 +31,9 @@ class ProfileCoordinator: Coordinator {
         }
 
         let hostingVC = UIHostingController(rootView: profileView)
-        hostingVC.title = "Perfil"
-        hostingVC.tabBarItem = UITabBarItem(title: "Perfil", image: UIImage(named: "user-square"), tag: 3)
+        let title = NSLocalizedString("profile_title", comment: "")
+        hostingVC.title = title
+        hostingVC.tabBarItem = UITabBarItem(title: title, image: UIImage(named: "user-square"), tag: 3)
         navigationController.setViewControllers([hostingVC], animated: false)
     }
 


### PR DESCRIPTION
## Summary
- Localize HomeCoordinator tab title using `NSLocalizedString` variable
- Localize ChangeCoordinator tab title using `NSLocalizedString` variable
- Localize Profile and Favorite coordinators tab titles via `NSLocalizedString`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Pesoblu.xcodeproj -scheme Pesoblu -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bf79a34c8333aef89490d02e5a55