### PR TITLE
fix: update iOS build destination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           SECRETS_PLIST: ${{ secrets.SECRETS_PLIST }}
       - name: Build iOS app
-        run: xcodebuild -scheme Pesoblu -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16' build
+        run: xcodebuild -scheme Pesoblu -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build


### PR DESCRIPTION
## Summary
- use generic iOS simulator destination for CI build

## Testing
- `act -j build` *(fails: act: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ac9cc308333a78af018f7d613d8